### PR TITLE
S3 Server fix and sidekiq ran same way as devops do

### DIFF
--- a/docker/test_server/docker_run
+++ b/docker/test_server/docker_run
@@ -10,6 +10,7 @@ sudo chown app:app /home/app/full_system/systems/admin/log
 sudo chown app:app /home/app/full_system/systems/api/log
 sudo chown app:app /home/app/full_system/systems/et3/node_modules
 sudo chown app:app /home/app/full_system/systems/admin/node_modules
+sudo chown app:app /home/app/minio_data
 
 sudo bash -c "SERVER_PORT=$SERVER_PORT SERVER_DOMAIN=$SERVER_DOMAIN envsubst '\$SERVER_PORT \$SERVER_DOMAIN' < /home/app/full_system/docker/test_server/nginx_config/default_server.conf.template > /etc/nginx/sites-enabled/default_server.conf"
 sudo bash -c "SERVER_PORT=$SERVER_PORT SERVER_DOMAIN=$SERVER_DOMAIN envsubst '\$SERVER_PORT \$SERVER_DOMAIN' < /home/app/full_system/docker/test_server/public/index.html.template > /home/app/public/index.html"

--- a/docker/test_server/sidekiq_init_templates/sidekiq_api.sh.template
+++ b/docker/test_server/sidekiq_init_templates/sidekiq_api.sh.template
@@ -15,4 +15,4 @@ export SMTP_HOSTNAME=smtp
 export SMTP_PORT=1025
 export RAILS_ENV=production
 
-exec /sbin/setuser app bundle exec sidekiq >>/home/app/full_system/systems/api/log/nginx_sidekiq.log 2>&1
+exec /sbin/setuser app /home/app/full_system/systems/api/run_sidekiq.sh >>/home/app/full_system/systems/api/log/nginx_sidekiq.log 2>&1


### PR DESCRIPTION
Fixed issue with permissions of the minio_data, causing it to not boot sometimes.

We now run sidekiq using the ./run_sidekiq.sh which is in the latest develop branch of the API (the pointer in here has changed to point to it)