### PR TITLE
Improved fake acas server and adjusted tests to suit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,6 @@ group :test do
   gem 'factory_bot'
   gem 'settingslogic'
   gem 'parallel_tests'
-  gem 'et_fake_acas_server', git: 'https://github.com/ministryofjustice/et_fake_acas_server.git', ref: 'eeaf6c89ce645e02d0f0a857aada546e1687d7ce'
 end
 
 group :development, :test do
@@ -36,4 +35,9 @@ group :development, :test do
   gem 'dotenv', '~> 2.2', '>= 2.2.2'
   gem 'faker', '~> 1.8', '>= 1.8.7'
 end
+
+group :production do
+  gem 'et_fake_acas_server', git: 'https://github.com/ministryofjustice/et_fake_acas_server.git', ref: 'ba78be596b80a6006b543a03f1b40ff6b130d5fc'
+end
+
 gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/ministryofjustice/et_fake_acas_server.git
-  revision: eeaf6c89ce645e02d0f0a857aada546e1687d7ce
-  ref: eeaf6c89ce645e02d0f0a857aada546e1687d7ce
+  revision: ba78be596b80a6006b543a03f1b40ff6b130d5fc
+  ref: ba78be596b80a6006b543a03f1b40ff6b130d5fc
   specs:
     et_fake_acas_server (0.1.0)
       activesupport (~> 5.2)

--- a/docker/test_server/docker_run
+++ b/docker/test_server/docker_run
@@ -67,7 +67,7 @@ else
 fi
 
 cd /home/app/full_system
-bash --login -c "rvm use ruby-2.5.1 && bundle install --jobs=4 --without=development"
+bash --login -c "rvm use ruby-2.5.1 && bundle install --jobs=4 --without=development --with=production test"
 FAKE_ACAS_GEM_PATH=`bundle show et_fake_acas_server`
 bash --login -c "cd $FAKE_ACAS_GEM_PATH && rvm use ruby-2.5.1 && bundle install --jobs=4"
 

--- a/features/factories/acas_mock_certificate_factory.rb
+++ b/features/factories/acas_mock_certificate_factory.rb
@@ -5,8 +5,8 @@ FactoryBot.define do
       date_of_receipt Time.parse('01/01/2017 12:00:00')
       date_of_issue Time.parse('01/12/2017 12:00:00')
       method_of_issue 'Email'
-      respondent_name 'Respondent Name'
-      claimant_name 'Claimant Name'
+      respondent_name 'Respondent’s Name'
+      claimant_name 'Claimant’s Name'
     end
     trait :mock_invalid do
       number 'R000201/18/68'

--- a/features/step_definitions/et3_landing_page_steps.rb
+++ b/features/step_definitions/et3_landing_page_steps.rb
@@ -17,6 +17,6 @@ Then(/^I should see other relevant links$/) do
     expect(start_page.sidebar.claim_link['href']).to eq 'https://www.gov.uk/employment-tribunals'
     expect(start_page.sidebar.response_link['href']).to eq 'https://www.gov.uk/being-taken-to-employment-tribunal-by-employee'
     expect(start_page.sidebar.contact_link['href']).to eq 'https://www.gov.uk/guidance/employment-tribunal-offices-and-venues'
-    expect(start_page.sidebar.download_link['href']).to eq 'https://www.employmenttribunals.service.gov.uk/form/pdf/141ET3_0414v2.pdf'
+    expect(start_page.sidebar.download_link['href']).to eq 'https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/719457/et3-eng.pdf'
     expect(start_page.sidebar.more_category_link['href']).to eq 'http://gov.uk/browse/working'
   end


### PR DESCRIPTION


The fake acas server has been upgraded to output data with unicode characters in - to provide a better test
The tests now expect a unicode apostrophe in the data to match the fake acas server (when running with fake acas server anyway)