### PR TITLE
RST-1160: ET3 Disability

### DIFF
--- a/docs/et-api.apib
+++ b/docs/et-api.apib
@@ -128,7 +128,9 @@ Creates a respondent response within the system and returns confirmation.
                         "fax_number":"02071234567",
                         "organisation_employ_gb":100,
                         "organisation_more_than_one_site":true,
-                        "employment_at_site_number":100
+                        "employment_at_site_number":100,
+                        "disability":true,
+                        "disability_information":"Lorem ipsum disability"
                     },
                     "uuid":"d80d85ee-9d5c-4c9c-bd86-aa3da851c622"
                 },
@@ -151,9 +153,7 @@ Creates a respondent response within the system and returns confirmation.
                         "reference":"Rep Ref",
                         "contact_preference":"Fax",
                         "email_address":"rep@domain.co.uk",
-                        "fax_number":"02073456789",
-                        "disability":true,
-                        "disability_information":"Lorem ipsum disability"
+                        "fax_number":"02073456789"
                     },
                     "uuid":"cdb093bf-82ee-4025-88a8-d00a6717a6aa"
                 }

--- a/features/et3/your_representative_page.feature
+++ b/features/et3/your_representative_page.feature
@@ -7,8 +7,8 @@ Background: ET3 your representative page
 
 Scenario: Successfully submit whether I have a representative
   When I successfully submit whether I have a representative
-  Then I should be taken to my employers contract claim page
+  Then I should be taken to disability page
 
 Scenario: Proceed without answering representative question
   When I click on next without providing whether I have a representative
-  Then I should be taken to my employers contract claim page
+  Then I should be taken to disability page

--- a/features/factories/et3_respondent_factory.rb
+++ b/features/factories/et3_respondent_factory.rb
@@ -24,6 +24,8 @@ FactoryBot.define do
     make_employer_contract_claim 'Yes'
     claim_information 'lorem ipsum info'
     email_receipt 'sivvoy.taing@hmcts.net'
+    disability 'Yes'
+    disability_information 'Lorem ipsum disability'
   end
 
   trait :upload_additional_information do
@@ -42,5 +44,7 @@ FactoryBot.define do
     make_employer_contract_claim 'nil'
     claim_information ''
     email_receipt ''
+    disability 'nil'
+    disability_information ''
   end
 end

--- a/features/factories/representative_factory.rb
+++ b/features/factories/representative_factory.rb
@@ -20,8 +20,6 @@ FactoryBot.define do
     representative_reference 'Rep Ref'
     representative_contact_preference 'Fax'
     representative_fax '0207 345 6789'
-    representative_disability 'Yes'
-    representative_disability_information 'Lorem ipsum disability'
   end
 
   trait :et3_no_representative do
@@ -43,7 +41,5 @@ FactoryBot.define do
     representative_contact_preference 'nil'
     representative_fax ''
     employer_contract_claim ''
-    representative_disability 'nil'
-    representative_disability_information ''
   end
 end

--- a/features/step_definitions/email_notifications_steps.rb
+++ b/features/step_definitions/email_notifications_steps.rb
@@ -48,7 +48,6 @@ When(/^a respondent completed an ET3 form$/) do
   et3_answer_earnings_and_benefits
   et3_answer_defend_claim_question
   et3_answer_representative
-  your_representative_page.next
   et3_answer_disability_question
   et3_employers_contract_claim
   additional_information

--- a/features/step_definitions/email_notifications_steps.rb
+++ b/features/step_definitions/email_notifications_steps.rb
@@ -48,6 +48,8 @@ When(/^a respondent completed an ET3 form$/) do
   et3_answer_earnings_and_benefits
   et3_answer_defend_claim_question
   et3_answer_representative
+  your_representative_page.next
+  et3_answer_disability_question
   et3_employers_contract_claim
   additional_information
   et3_confirmation_of_supplied_details

--- a/features/step_definitions/et3_additional_information_page.rb
+++ b/features/step_definitions/et3_additional_information_page.rb
@@ -8,6 +8,7 @@ Given(/^I am on the ET3 additional information page$/) do
   et3_answer_earnings_and_benefits
   et3_answer_defend_claim_question
   et3_answer_representative
+  et3_answer_disability_question
   et3_employers_contract_claim
   expect(additional_information_page).to be_displayed
 end

--- a/features/step_definitions/et3_confirmation_of_supplied_details_page_steps.rb
+++ b/features/step_definitions/et3_confirmation_of_supplied_details_page_steps.rb
@@ -8,6 +8,7 @@ Given(/^I am on the ET3 confirmation of supplied details page$/) do
   et3_answer_earnings_and_benefits
   et3_answer_defend_claim_question
   et3_answer_representative
+  et3_answer_disability_question
   et3_employers_contract_claim
   additional_information
 end

--- a/features/step_definitions/et3_employers_contract_claim_steps.rb
+++ b/features/step_definitions/et3_employers_contract_claim_steps.rb
@@ -8,6 +8,7 @@ Given(/^I am on the ET3 employers contract claim page$/) do
   et3_answer_earnings_and_benefits
   et3_answer_defend_claim_question
   et3_answer_representative
+  et3_answer_disability_question
   expect(employers_contract_claim_page).to be_displayed
 end
 

--- a/features/step_definitions/et3_form_submission_page_steps.rb
+++ b/features/step_definitions/et3_form_submission_page_steps.rb
@@ -8,6 +8,7 @@ Given(/^I am on the ET3 form submission page$/) do
   et3_answer_earnings_and_benefits
   et3_answer_defend_claim_question
   et3_answer_representative
+  et3_answer_disability_question
   et3_employers_contract_claim
   additional_information
   et3_confirmation_of_supplied_details

--- a/features/step_definitions/et3_response_steps.rb
+++ b/features/step_definitions/et3_response_steps.rb
@@ -4,8 +4,8 @@ When(/^the completed Employment Tribunal response form is submitted$/) do
   et3_answer_claimants_details
   et3_answer_earnings_and_benefits
   et3_answer_defend_claim_question
-  et3_answer_disability_question
   et3_answer_representative
+  et3_answer_disability_question
   et3_employers_contract_claim
   additional_information
   et3_confirmation_of_supplied_details
@@ -28,6 +28,7 @@ When(/^an employer responds to mandatory questions$/) do
   response_page.defend_claim_question.set_for(user)
   response_page.next
   et3_answer_representative
+  et3_answer_disability_question
   employers_contract_claim_page.next
   additional_information
   confirmation_of_supplied_details_page.next
@@ -50,6 +51,7 @@ When("an employer responds to a claim with special characters in the company's n
   response_page.defend_claim_question.set_for(user)
   response_page.next
   et3_answer_representative
+  et3_answer_disability_question
   employers_contract_claim_page.next
   additional_information
   confirmation_of_supplied_details_page.next

--- a/features/step_definitions/et3_response_steps.rb
+++ b/features/step_definitions/et3_response_steps.rb
@@ -4,6 +4,7 @@ When(/^the completed Employment Tribunal response form is submitted$/) do
   et3_answer_claimants_details
   et3_answer_earnings_and_benefits
   et3_answer_defend_claim_question
+  et3_answer_disability_question
   et3_answer_representative
   et3_employers_contract_claim
   additional_information

--- a/features/step_definitions/et3_your_representative_page_steps.rb
+++ b/features/step_definitions/et3_your_representative_page_steps.rb
@@ -18,6 +18,6 @@ When(/^I click on next without providing whether I have a representative$/) do
   your_representative_page.next
 end
 
-Then(/^I should be taken to my employers contract claim page$/) do
-  expect(employers_contract_claim_page).to be_displayed
+Then(/^I should be taken to disability page$/) do
+  expect(disability_page).to be_displayed
 end

--- a/test_common/file_objects/et3_pdf_file.rb
+++ b/test_common/file_objects/et3_pdf_file.rb
@@ -21,7 +21,7 @@ module EtFullSystem
           has_response_for?(response, errors: errors, indent: indent) &&
           has_contract_claim_for?(respondent, errors: errors, indent: indent) &&
           has_representative_for?(representative, errors: errors, indent: indent) &&
-          has_disability_for?(representative, errors: errors, indent: indent)
+          has_disability_for?(respondent, errors: errors, indent: indent)
         end
 
         def has_header_for?(respondent, errors: [], indent: 1)
@@ -154,15 +154,14 @@ module EtFullSystem
           end
         end
 
-        def has_disability_for?(representative, errors: [], indent: 1)
-          return has_no_disability?(errors: errors, indent: indent) if representative.nil?
+        def has_disability_for?(respondent, errors: [], indent: 1)
           validate_fields section: :disability, errors: errors, indent: indent do
-            if representative.representative_disability == 'nil'
+            if respondent.disability == 'nil'
               expect(field_values).to include '8.1 tick box' => 'Off'
             else
-              expect(field_values).to include '8.1 tick box' => representative.representative_disability.downcase
+              expect(field_values).to include '8.1 tick box' => respondent.disability.downcase
             end
-            expect(field_values).to include '8.1 if yes' => representative.representative_disability_information
+            expect(field_values).to include '8.1 if yes' => respondent.disability_information
           end
         end
 

--- a/test_common/helpers/et3/et3_response_helper.rb
+++ b/test_common/helpers/et3/et3_response_helper.rb
@@ -97,17 +97,14 @@ module EtFullSystem
           your_representatives_details_page.representative_dx_number_question.set(user.dx_number)
           your_representatives_details_page.representative_reference_question.set(user.representative_reference)
           your_representatives_details_page.representative_contact_preference_question.set_for(user)
-          your_representatives_details_page.representative_disability_question.set_for(user)
           your_representatives_details_page.next
         else
           your_representative_page.next
-        end 
-        
+        end
       end
 
-       def et3_answer_disability_question
-        user = @claimant[0]
-        binding.pry
+      def et3_answer_disability_question
+        user = @respondent[0]
         disability_page.disability_question.set_for(user)
 
         disability_page.next

--- a/test_common/helpers/et3/et3_response_helper.rb
+++ b/test_common/helpers/et3/et3_response_helper.rb
@@ -105,6 +105,14 @@ module EtFullSystem
         
       end
 
+       def et3_answer_disability_question
+        user = @claimant[0]
+        binding.pry
+        disability_page.disability_question.set_for(user)
+
+        disability_page.next
+      end
+
       def et3_employers_contract_claim
         user = @respondent[0]
         employers_contract_claim_page.make_employer_contract_claim_question.set_for(user)

--- a/test_common/helpers/pages.rb
+++ b/test_common/helpers/pages.rb
@@ -82,6 +82,10 @@ module EtFullSystem
         EtFullSystem::Test::Et3::ResponsePage.new
       end
 
+       def disability_page
+        EtFullSystem::Test::Et3::DisabilityPage.new
+      end
+
       def your_representative_page
         EtFullSystem::Test::Et3::YourRepresentativePage.new
       end

--- a/test_common/helpers/pages.rb
+++ b/test_common/helpers/pages.rb
@@ -82,12 +82,12 @@ module EtFullSystem
         EtFullSystem::Test::Et3::ResponsePage.new
       end
 
-       def disability_page
-        EtFullSystem::Test::Et3::DisabilityPage.new
-      end
-
       def your_representative_page
         EtFullSystem::Test::Et3::YourRepresentativePage.new
+      end
+
+      def disability_page
+        EtFullSystem::Test::Et3::DisabilityPage.new
       end
 
       def your_representatives_details_page

--- a/test_common/messaging/en.yml
+++ b/test_common/messaging/en.yml
@@ -204,8 +204,9 @@ en:
       fax:
         label: Fax
         input_label: Fax number
-    representative_disability:
-      label: Does your representative have a disability? (optional)
+    # Disability Page
+    disability:
+      label: Do you have a disability? (optional)
       'yes':
         label: 'Yes'
       'no':

--- a/test_common/page_objects/et3/confirmation_of_supplied_details_page.rb
+++ b/test_common/page_objects/et3/confirmation_of_supplied_details_page.rb
@@ -199,10 +199,14 @@ module EtFullSystem
           section :fax_row, :table_row_with_td_labelled, 'questions.representative_contact_preference.fax.input_label', exact: true do
             element :fax_answer, :return_answer
           end
-          section :representative_disability_row, :table_row_with_td_labelled, 'questions.representative_disability.label', exact: true do
-            element :representative_disability_answer, :return_answer
+          element :back_to_top, 'a', text: 'Back to the top'
+        end
+
+        section :confirmation_of_disability_answers, :table_captioned, 'questions.confirmation_of_disability_answers.caption', exact: true do
+          section :disability_row, :table_row_with_td_labelled, 'questions.disability.label', exact: true do
+            element :disability_answer, :return_answer
           end
-          section :disability_information_row, :table_row_with_td_labelled, 'questions.representative_disability.disability_information.label', exact: true do
+          section :disability_information_row, :table_row_with_td_labelled, 'questions.disability.disability_information.label', exact: true do
             element :disability_information_answer, :return_answer
           end
           element :back_to_top, 'a', text: 'Back to the top'

--- a/test_common/page_objects/et3/disability_page.rb
+++ b/test_common/page_objects/et3/disability_page.rb
@@ -1,0 +1,41 @@
+require_relative './base_page'
+module EtFullSystem
+  module Test
+    module Et3
+      class DisabilityPage < BasePage
+      set_url '/respond/disability'
+
+      element :error_header, :error_titled, 'errors.header', exact: true
+
+      section :disability_question, :single_choice_option, 'questions.disability.label', exact: false do
+        section :yes, :gds_multiple_choice_option, 'questions.disability.yes.label', exact: false do
+            element :selector, :css, 'input[type="radio"]'
+            delegate :set, to: :selector
+          end
+          section :no, :gds_multiple_choice_option, 'questions.disability.no.label', exact: false do
+            element :selector, :css, 'input[type="radio"]'
+            delegate :set, to: :selector          
+          end
+          section :disability_information, :textarea_labelled, 'questions.disability.disability_information.label', exact: :false do
+            delegate :set, to: :root_element
+          end
+          element :error_too_long, :exact_error_text, 'errors.messages.too_long', exact: false
+
+        def set_for(user_persona)
+          if user_persona.disability == "Yes"
+            yes.set(true)
+            disability_information.set(user_persona.disability_information)
+          else
+            no.set(true)
+          end
+        end
+      end
+
+      element :continue_button, :button, "Save and continue"
+      def next
+        continue_button.click
+      end
+      end
+    end
+  end
+end

--- a/test_common/page_objects/et3/your_representatives_details_page.rb
+++ b/test_common/page_objects/et3/your_representatives_details_page.rb
@@ -145,28 +145,6 @@ module EtFullSystem
             end
           end
         end
-        section :representative_disability_question, :single_choice_option, 'questions.representative_disability.label', exact: false do
-          section :yes, :gds_multiple_choice_option, 'questions.representative_disability.yes.label', exact: true do
-            element :selector, :css, 'input'
-            delegate :set, to: :selector
-          end
-          section :no, :gds_multiple_choice_option, 'questions.representative_disability.no.label', exact: true do
-            element :selector, :css, 'input'
-            delegate :set, to: :selector
-          end
-          section :representative_disability_information, :textarea_labelled, 'questions.representative_disability.disability_information.label', exact: :false do
-            delegate :set, to: :root_element
-          end
-          element :error_too_long, :exact_error_text, 'errors.messages.too_long', exact: false
-          def set_for(user)
-            if user.representative_disability == "Yes"
-              yes.set(true)
-              representative_disability_information.set(user.representative_disability_information)
-            else
-              no.set(true)
-            end
-          end
-        end
         element :continue_button, :button, "Save and continue"
         def next
           continue_button.click


### PR DESCRIPTION
ET3 moved `representative disability` into its own page, `disability`. This brings the full system in line with that change.

~**NB: The pdf doesn't quite work properly and needs to be fixed!**~
PDF wasn't working as this was a breaking change in the API. Resolved with submodule update in 7acbfc2.