### PR TITLE
Bump Postgres to 9.6.9 to match production

### DIFF
--- a/docker/test_server/docker-compose.yml
+++ b/docker/test_server/docker-compose.yml
@@ -63,7 +63,7 @@ services:
 
 #command: bash -lc "cd /home/app/full_system/systems/api && REDIS_DATABASE=2 bundle exec sidekiq"
   db:
-    image: postgres:9.3.5
+    image: postgres:9.6.9
     networks:
       - et_full_system
     ports:


### PR DESCRIPTION
To upgrade run `./bin/dev/test_server down -v` (note: this deletes data) followed by `./bin/dev/test_server up` from the full-system root.