### PR TITLE
Full server upgrade and increased timeout for claimants.json

### DIFF
--- a/docker/test_server/docker_run
+++ b/docker/test_server/docker_run
@@ -41,23 +41,26 @@ fi
 sudo bash -c "SERVER_PORT=$SERVER_PORT SERVER_DOMAIN=$SERVER_DOMAIN envsubst '\$SERVER_PORT \$SERVER_DOMAIN' < /home/app/full_system/docker/test_server/acas_templates/acas_wsdl.txt.template > /home/app/acas_wsdl.txt"
 
 
-
 sudo bash -c "SERVER_PORT=$SERVER_PORT SERVER_DOMAIN=$SERVER_DOMAIN envsubst '\$SERVER_PORT \$SERVER_DOMAIN' < /home/app/full_system/docker/test_server/nginx_config/s3_server.conf.template > /etc/nginx/sites-enabled/s3_server.conf"
 sudo bash -c "SERVER_PORT=$SERVER_PORT SERVER_DOMAIN=$SERVER_DOMAIN envsubst '\$SERVER_PORT \$SERVER_DOMAIN' < /home/app/full_system/docker/test_server/nginx_config/smtp_server.conf.template > /etc/nginx/sites-enabled/smtp_server.conf"
 sudo bash -c "SERVER_PORT=$SERVER_PORT SERVER_DOMAIN=$SERVER_DOMAIN envsubst '\$SERVER_PORT \$SERVER_DOMAIN' < /home/app/full_system/docker/test_server/sidekiq_init_templates/sidekiq_api.sh.template > /etc/service/sidekiq_api/run"
 sudo bash -c "SERVER_PORT=$SERVER_PORT SERVER_DOMAIN=$SERVER_DOMAIN envsubst '\$SERVER_PORT \$SERVER_DOMAIN' < /home/app/full_system/docker/test_server/sidekiq_init_templates/sidekiq_et1.sh.template > /etc/service/sidekiq_et1/run"
 sudo chmod +x /etc/service/sidekiq_api/run
 sudo chmod +x /etc/service/sidekiq_et1/run
-cd /home/app/et_fake_acas_server && bundle install --jobs=4
-bash --login -c "cd /home/app/full_system/systems/et1 && rvm use ruby-2.3.3 && bundle install --jobs=4 --without=development test --with=production && npm install && RAILS_ENV=local bundle exec rake db:create db:migrate assets:precompile"
-bash --login -c "cd /home/app/full_system/systems/et3 && rvm use ruby-2.5.1 && bundle install --jobs=4 --without=development test --with=production && RAILS_ENV=production bundle exec rails db:create db:migrate assets:precompile && bundle exec rake non_digest_assets"
-bash --login -c "cd /home/app/full_system/systems/api && rvm use ruby-2.5.1 && bundle install --jobs=4 --without=development test --with=production && RAILS_ENV=production bundle exec rails db:create db:migrate db:seed"
-bash --login -c "cd /home/app/full_system/systems/admin && rvm use ruby-2.5.1 && bundle install --jobs=4 --without=development test --with=production && RAILS_ENV=production SEED_EXAMPLE_USERS=true bundle exec rails db:seed assets:precompile"
+echo "------------------------------------------------ ET1 SERVICE ---------------------------------------------------"
+bash --login -c "cd /home/app/full_system/systems/et1 && /usr/local/rvm/bin/rvm use && bundle install --jobs=4 --without=development test --with=production && npm install && RAILS_ENV=local bundle exec rake db:create db:migrate assets:precompile"
+echo "------------------------------------------------ ET3 SERVICE ---------------------------------------------------"
+bash --login -c "cd /home/app/full_system/systems/et3 && /usr/local/rvm/bin/rvm use && bundle install --jobs=4 --without=development test --with=production && RAILS_ENV=production bundle exec rails db:create db:migrate assets:precompile && bundle exec rake non_digest_assets"
+echo "------------------------------------------------ API SERVICE ---------------------------------------------------"
+bash --login -c "cd /home/app/full_system/systems/api && /usr/local/rvm/bin/rvm use && bundle install --jobs=4 --without=development test --with=production && RAILS_ENV=production bundle exec rails db:create db:migrate db:seed"
+echo "------------------------------------------------ ADMIN SERVICE ---------------------------------------------------"
+bash --login -c "cd /home/app/full_system/systems/admin && /usr/local/rvm/bin/rvm use && bundle install --jobs=4 --without=development test --with=production && RAILS_ENV=production SEED_EXAMPLE_USERS=true bundle exec rails db:seed assets:precompile"
 
+echo "------------------------------------------------ ATOS FILE TRANSFER SERVICE ---------------------------------------------------"
 cd /home/app/full_system/systems/api
 ATOS_GEM_PATH=`bundle show et_atos_file_transfer`
 export ATOS_GEM_PATH
-bash --login -c "cd $ATOS_GEM_PATH && rvm use ruby-2.5.1 && bundle install --jobs=4"
+bash --login -c "cd $ATOS_GEM_PATH && /usr/local/rvm/bin/rvm use && bundle install --jobs=4"
 
 if [ -z "$MY_ATOS" ]; then
     sudo bash -c "SERVER_PORT=$SERVER_PORT SERVER_DOMAIN=$SERVER_DOMAIN ATOS_GEM_PATH=$ATOS_GEM_PATH envsubst '\$SERVER_PORT \$SERVER_DOMAIN \$ATOS_GEM_PATH' < /home/app/full_system/docker/test_server/nginx_config/atos_server.conf.template > /etc/nginx/sites-enabled/atos_server.conf"
@@ -66,9 +69,11 @@ else
 fi
 
 cd /home/app/full_system
-bash --login -c "rvm use ruby-2.5.1 && bundle install --jobs=4 --without=development --with=production test"
+echo "------------------------------------------------ FULL SYSTEM ---------------------------------------------------"
+bash --login -c "/usr/local/rvm/bin/rvm use && bundle install --jobs=4 --without=development --with=production test"
+echo "------------------------------------------------ FAKE ACAS SERVICE ---------------------------------------------------"
 FAKE_ACAS_GEM_PATH=`bundle show et_fake_acas_server`
-bash --login -c "cd $FAKE_ACAS_GEM_PATH && rvm use ruby-2.5.1 && bundle install --jobs=4"
+bash --login -c "cd $FAKE_ACAS_GEM_PATH && /usr/local/rvm/bin/rvm use && bundle install --jobs=4"
 
 if [ -z "$MY_FAKE_ACAS" ]; then
     sudo bash -c "SERVER_PORT=$SERVER_PORT SERVER_DOMAIN=$SERVER_DOMAIN FAKE_ACAS_GEM_PATH=$FAKE_ACAS_GEM_PATH envsubst '\$SERVER_PORT \$SERVER_DOMAIN \$FAKE_ACAS_GEM_PATH' < /home/app/full_system/docker/test_server/nginx_config/fake_acas_server.conf.template > /etc/nginx/sites-enabled/fake_acas_server.conf"
@@ -76,6 +81,7 @@ else
     sudo bash -c "SERVER_PORT=$SERVER_PORT SERVER_DOMAIN=$SERVER_DOMAIN MY_FAKE_ACAS=$MY_FAKE_ACAS envsubst '\$SERVER_PORT \$SERVER_DOMAIN \$MY_FAKE_ACAS' < /home/app/full_system/docker/test_server/nginx_config/fake_acas_local.conf.template > /etc/nginx/sites-enabled/fake_acas_server.conf"
 fi
 
+echo "------------------------------------------------ STARTING WEB SERVER ---------------------------------------------------"
 
 /home/app/full_system/docker/test_server/setup_buckets > /home/app/setup_buckets.log &
 sudo -E DB_HOST=$DB_HOST DB_USERNAME=$DB_USERNAME /sbin/my_init

--- a/docker/test_server/sidekiq_init_templates/sidekiq_api.sh.template
+++ b/docker/test_server/sidekiq_init_templates/sidekiq_api.sh.template
@@ -18,4 +18,4 @@ export RAILS_MAX_THREADS=10
 ATOS_API_USERNAME=atos
 ATOS_API_PASSWORD=password
 
-exec /sbin/setuser app bash --login -c "rvm use ruby-2.5.1 && /home/app/full_system/systems/api/run_sidekiq.sh >>/home/app/full_system/systems/api/log/nginx_sidekiq.log 2>&1"
+exec /sbin/setuser app bash --login -c "/usr/local/rvm/bin/rvm use && /home/app/full_system/systems/api/run_sidekiq.sh >>/home/app/full_system/systems/api/log/nginx_sidekiq.log 2>&1"

--- a/docker/test_server/sidekiq_init_templates/sidekiq_et1.sh.template
+++ b/docker/test_server/sidekiq_init_templates/sidekiq_et1.sh.template
@@ -20,4 +20,4 @@ export AWS_ENDPOINT=http://s3.${SERVER_DOMAIN}:${SERVER_PORT}
 export AWS_S3_FORCE_PATH_STYLE=true
 export ET_API_URL=http://api.${SERVER_DOMAIN}:${SERVER_PORT}/api/v2
 
-exec /sbin/setuser app bash --login -c "rvm use ruby-2.3.3 && bundle exec sidekiq >>/home/app/full_system/systems/et1/log/nginx_sidekiq.log 2>&1"
+exec /sbin/setuser app bash --login -c "/usr/local/rvm/bin/rvm use && bundle exec sidekiq >>/home/app/full_system/systems/et1/log/nginx_sidekiq.log 2>&1"

--- a/features/step_definitions/et1_atos_export_steps.rb
+++ b/features/step_definitions/et1_atos_export_steps.rb
@@ -1,7 +1,7 @@
 Then(/^I can download the form and validate in PDF format$/) do
   within_admin_window do
     api = EtFullSystem::Test::AdminApi.new
-    expect { api.claimants_api }.to eventually include a_hash_including(first_name: @claimants[0].dig(:first_name))
+    expect { api.claimants_api }.to eventually include a_hash_including(first_name: @claimants[0].dig(:first_name)), timeout: 30, sleep: 2
     admin_pages.jobs_page.run_export_claims_cron_job
   end
   expect { atos_interface }.to eventually have_zip_file_containing(:et1_claim_pdf_for, user: @claimants[0]), timeout: 30, sleep: 2
@@ -10,7 +10,7 @@ end
 Then(/^I can download the form and validate in TXT format$/) do
   within_admin_window do
     api = EtFullSystem::Test::AdminApi.new
-    expect { api.claimants_api }.to eventually include a_hash_including(first_name: @claimants[0].dig(:first_name))
+    expect { api.claimants_api }.to eventually include a_hash_including(first_name: @claimants[0].dig(:first_name)), timeout: 30, sleep: 2
     admin_pages.jobs_page.run_export_claims_cron_job
   end
   expect { atos_interface }.to eventually have_zip_file_containing(:et1_claim_txt_for, user: @claimants[0]), timeout: 30, sleep: 2
@@ -20,7 +20,7 @@ end
 Then(/^I can download the uploaded CSV data and validate in TXT format$/) do
   within_admin_window do
     api = EtFullSystem::Test::AdminApi.new
-    expect { api.claimants_api }.to eventually include a_hash_including(first_name: @claimants[0].dig(:first_name))
+    expect { api.claimants_api }.to eventually include a_hash_including(first_name: @claimants[0].dig(:first_name)), timeout: 30, sleep: 2
     admin_pages.jobs_page.run_export_claims_cron_job
   end
   expect { atos_interface }.to eventually have_zip_file_containing(:et1a_claim_txt_for, user: @claimants[0]), timeout: 30, sleep: 2
@@ -30,7 +30,7 @@ end
 Then(/^I can download the uploaded CSV data and validate in CSV format$/) do
   within_admin_window do
     api = EtFullSystem::Test::AdminApi.new
-    expect { api.claimants_api }.to eventually include a_hash_including(first_name: @claimants[0].dig(:first_name))
+    expect { api.claimants_api }.to eventually include a_hash_including(first_name: @claimants[0].dig(:first_name)), timeout: 30, sleep: 2
     admin_pages.jobs_page.run_export_claims_cron_job
   end
   expect { atos_interface }.to eventually have_zip_file_containing(:et1_claim_csv_for, user: @claimants[0]), timeout: 30, sleep: 2
@@ -39,7 +39,7 @@ end
 Then(/^I can download the form and validate in Rich Text format$/) do
   within_admin_window do
     api = EtFullSystem::Test::AdminApi.new
-    expect { api.claimants_api }.to eventually include a_hash_including(first_name: @claimants[0].dig(:first_name))
+    expect { api.claimants_api }.to eventually include a_hash_including(first_name: @claimants[0].dig(:first_name)), timeout: 30, sleep: 2
     admin_pages.jobs_page.run_export_claims_cron_job
   end
   expect { atos_interface }.to eventually have_zip_file_containing(:et1_claim_rtf_for, user: @claimants[0]), timeout: 30, sleep: 2
@@ -48,7 +48,7 @@ end
 Then(/^I can download the form and validate the TXT file contained 3 employers details$/) do
   within_admin_window do
     api = EtFullSystem::Test::AdminApi.new
-    expect { api.claimants_api }.to eventually include a_hash_including(first_name: @claimants[0].dig(:first_name))
+    expect { api.claimants_api }.to eventually include a_hash_including(first_name: @claimants[0].dig(:first_name)), timeout: 30, sleep: 2
     admin_pages.jobs_page.run_export_claims_cron_job
   end
   expect { atos_interface }.to eventually have_zip_file_containing(:et1_claim_txt_for, user: @claimants[0]), timeout: 30, sleep: 2
@@ -58,7 +58,7 @@ end
 Then("I can download the form and validate that the filname start with {string}") do |string|
   within_admin_window do
     api = EtFullSystem::Test::AdminApi.new
-    expect { api.claimants_api }.to eventually include a_hash_including(first_name: @claimants[0].dig(:first_name))
+    expect { api.claimants_api }.to eventually include a_hash_including(first_name: @claimants[0].dig(:first_name)), timeout: 30, sleep: 2
     admin_pages.jobs_page.run_export_claims_cron_job
   end
   expect { atos_interface }.to eventually have_zip_file_containing(:et1_filename_start_with, user: @claimants[0], local_office: string), timeout: 30, sleep: 2

--- a/features/step_definitions/et1_atos_export_steps.rb
+++ b/features/step_definitions/et1_atos_export_steps.rb
@@ -1,7 +1,7 @@
 Then(/^I can download the form and validate in PDF format$/) do
   within_admin_window do
     api = EtFullSystem::Test::AdminApi.new
-    expect { api.claimants_api }.to eventually include a_hash_including(first_name: @claimants[0].dig(:first_name)), timeout: 30, sleep: 2
+    expect { api.claimants_api }.to eventually include(a_hash_including(first_name: @claimants[0].dig(:first_name))), timeout: 30, sleep: 2
     admin_pages.jobs_page.run_export_claims_cron_job
   end
   expect { atos_interface }.to eventually have_zip_file_containing(:et1_claim_pdf_for, user: @claimants[0]), timeout: 30, sleep: 2
@@ -10,7 +10,7 @@ end
 Then(/^I can download the form and validate in TXT format$/) do
   within_admin_window do
     api = EtFullSystem::Test::AdminApi.new
-    expect { api.claimants_api }.to eventually include a_hash_including(first_name: @claimants[0].dig(:first_name)), timeout: 30, sleep: 2
+    expect { api.claimants_api }.to eventually include(a_hash_including(first_name: @claimants[0].dig(:first_name))), timeout: 30, sleep: 2
     admin_pages.jobs_page.run_export_claims_cron_job
   end
   expect { atos_interface }.to eventually have_zip_file_containing(:et1_claim_txt_for, user: @claimants[0]), timeout: 30, sleep: 2
@@ -20,7 +20,7 @@ end
 Then(/^I can download the uploaded CSV data and validate in TXT format$/) do
   within_admin_window do
     api = EtFullSystem::Test::AdminApi.new
-    expect { api.claimants_api }.to eventually include a_hash_including(first_name: @claimants[0].dig(:first_name)), timeout: 30, sleep: 2
+    expect { api.claimants_api }.to eventually include(a_hash_including(first_name: @claimants[0].dig(:first_name))), timeout: 30, sleep: 2
     admin_pages.jobs_page.run_export_claims_cron_job
   end
   expect { atos_interface }.to eventually have_zip_file_containing(:et1a_claim_txt_for, user: @claimants[0]), timeout: 30, sleep: 2
@@ -30,7 +30,7 @@ end
 Then(/^I can download the uploaded CSV data and validate in CSV format$/) do
   within_admin_window do
     api = EtFullSystem::Test::AdminApi.new
-    expect { api.claimants_api }.to eventually include a_hash_including(first_name: @claimants[0].dig(:first_name)), timeout: 30, sleep: 2
+    expect { api.claimants_api }.to eventually include(a_hash_including(first_name: @claimants[0].dig(:first_name))), timeout: 30, sleep: 2
     admin_pages.jobs_page.run_export_claims_cron_job
   end
   expect { atos_interface }.to eventually have_zip_file_containing(:et1_claim_csv_for, user: @claimants[0]), timeout: 30, sleep: 2
@@ -39,7 +39,7 @@ end
 Then(/^I can download the form and validate in Rich Text format$/) do
   within_admin_window do
     api = EtFullSystem::Test::AdminApi.new
-    expect { api.claimants_api }.to eventually include a_hash_including(first_name: @claimants[0].dig(:first_name)), timeout: 30, sleep: 2
+    expect { api.claimants_api }.to eventually include(a_hash_including(first_name: @claimants[0].dig(:first_name))), timeout: 30, sleep: 2
     admin_pages.jobs_page.run_export_claims_cron_job
   end
   expect { atos_interface }.to eventually have_zip_file_containing(:et1_claim_rtf_for, user: @claimants[0]), timeout: 30, sleep: 2
@@ -48,7 +48,7 @@ end
 Then(/^I can download the form and validate the TXT file contained 3 employers details$/) do
   within_admin_window do
     api = EtFullSystem::Test::AdminApi.new
-    expect { api.claimants_api }.to eventually include a_hash_including(first_name: @claimants[0].dig(:first_name)), timeout: 30, sleep: 2
+    expect { api.claimants_api }.to eventually include(a_hash_including(first_name: @claimants[0].dig(:first_name))), timeout: 30, sleep: 2
     admin_pages.jobs_page.run_export_claims_cron_job
   end
   expect { atos_interface }.to eventually have_zip_file_containing(:et1_claim_txt_for, user: @claimants[0]), timeout: 30, sleep: 2
@@ -58,7 +58,7 @@ end
 Then("I can download the form and validate that the filname start with {string}") do |string|
   within_admin_window do
     api = EtFullSystem::Test::AdminApi.new
-    expect { api.claimants_api }.to eventually include a_hash_including(first_name: @claimants[0].dig(:first_name)), timeout: 30, sleep: 2
+    expect { api.claimants_api }.to eventually include(a_hash_including(first_name: @claimants[0].dig(:first_name))), timeout: 30, sleep: 2
     admin_pages.jobs_page.run_export_claims_cron_job
   end
   expect { atos_interface }.to eventually have_zip_file_containing(:et1_filename_start_with, user: @claimants[0], local_office: string), timeout: 30, sleep: 2

--- a/features/support/record_video.rb
+++ b/features/support/record_video.rb
@@ -1,6 +1,7 @@
 require_relative './test_common'
 record_video_mode = ENV.fetch('RECORD_VIDEO', 'on_failure')  # Can be 'on_failure', 'false', 'true', '@tagname,@other_tagname'
 selenium_url = ENV.fetch('SELENIUM_URL', 'http://localhost:4444/wd/hub')
+FileUtils.rm Dir.glob(File.join(Capybara::Screenshot.capybara_root, '*.flv')) # Always start with empty dir
 if selenium_url || ENV.key?('RECORD_VNC_FROM')
   selenium_host = URI.parse(selenium_url).host
   vnc_uri = URI.parse(ENV.fetch('RECORD_VNC_FROM', "vnc://#{selenium_host}:5900"))

--- a/test_common/video_recorder.rb
+++ b/test_common/video_recorder.rb
@@ -15,7 +15,6 @@ module EtFullSystem
       def start
         return if command.empty?
         FileUtils.mkdir_p dir unless Dir.exist?(dir)
-        FileUtils.rm Dir.glob(File.join(dir, '*.flv'))
         command_line = "#{command} -P #{password_file.path} -o #{file_path} #{host} #{port}"
         self.process = IO.popen(command_line)
         at_exit { stop }


### PR DESCRIPTION
Removed hard coding of ruby versions in full system.  'rvm use' will use the version specified in .ruby-version
Increase timeout from 5 to 30 when checking for claimants.json
Fix video recording - now only deletes all files at the beginning