### PR TITLE
Removed ruby 2.3.3 from dockerfile now that ET1 uses 2.5.1

### DIFF
--- a/docker/test_server/Dockerfile
+++ b/docker/test_server/Dockerfile
@@ -74,7 +74,6 @@ WORKDIR /home/app/full_system/systems
 RUN echo "app ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/user && chmod 0440 /etc/sudoers.d/user
 RUN usermod -u $APP_UID app
 USER app
-RUN bash --login -c "rvm_rubygems_version=2.7.6 rvm install ruby-2.3.3 && rvm --default use 2.5.1"
 
 RUN cd /home/app
 ENV HOME /home/app


### PR DESCRIPTION
Removed ruby 2.3.3 from dockerfile now that ET1 uses 2.5.1