### PR TITLE
Fix Travis Build

### DIFF
--- a/docker/test_server/docker-compose.yml
+++ b/docker/test_server/docker-compose.yml
@@ -23,6 +23,10 @@ services:
       - et3_assets:/home/app/full_system/systems/et3/public/assets
       - admin_assets:/home/app/full_system/systems/admin/public/assets
       - s3_data:/home/app/minio_data
+      - et1_bundle_dir:/home/app/full_system/systems/et1/.bundle
+      - api_bundle_dir:/home/app/full_system/systems/api/.bundle
+      - et3_bundle_dir:/home/app/full_system/systems/et3/.bundle
+      - admin_bundle_dir:/home/app/full_system/systems/admin/.bundle
     environment:
       DB_HOST: 'db'
       DB_USERNAME: 'postgres'
@@ -87,6 +91,10 @@ volumes:
   et3_assets:
   admin_assets:
   s3_data:
+  et1_bundle_dir:
+  api_bundle_dir:
+  et3_bundle_dir:
+  admin_bundle_dir:
 networks:
   et_full_system:
 

--- a/docker/test_server/docker-compose.yml
+++ b/docker/test_server/docker-compose.yml
@@ -23,10 +23,6 @@ services:
       - et3_assets:/home/app/full_system/systems/et3/public/assets
       - admin_assets:/home/app/full_system/systems/admin/public/assets
       - s3_data:/home/app/minio_data
-      - et1_bundle_dir:/home/app/full_system/systems/et1/.bundle
-      - api_bundle_dir:/home/app/full_system/systems/api/.bundle
-      - et3_bundle_dir:/home/app/full_system/systems/et3/.bundle
-      - admin_bundle_dir:/home/app/full_system/systems/admin/.bundle
     environment:
       DB_HOST: 'db'
       DB_USERNAME: 'postgres'
@@ -91,10 +87,6 @@ volumes:
   et3_assets:
   admin_assets:
   s3_data:
-  et1_bundle_dir:
-  api_bundle_dir:
-  et3_bundle_dir:
-  admin_bundle_dir:
 networks:
   et_full_system:
 

--- a/docker/test_server/docker_run
+++ b/docker/test_server/docker_run
@@ -58,7 +58,7 @@ bash --login -c "cd /home/app/full_system/systems/admin && /usr/local/rvm/bin/rv
 
 echo "------------------------------------------------ ATOS FILE TRANSFER SERVICE ---------------------------------------------------"
 cd /home/app/full_system/systems/api
-ATOS_GEM_PATH=`bundle show et_atos_file_transfer`
+ATOS_GEM_PATH=`bundle show et_atos_file_transfer | tail -1`
 export ATOS_GEM_PATH
 bash --login -c "cd $ATOS_GEM_PATH && /usr/local/rvm/bin/rvm use && bundle install --jobs=4"
 
@@ -72,7 +72,7 @@ cd /home/app/full_system
 echo "------------------------------------------------ FULL SYSTEM ---------------------------------------------------"
 bash --login -c "/usr/local/rvm/bin/rvm use && bundle install --jobs=4 --without=development --with=production test"
 echo "------------------------------------------------ FAKE ACAS SERVICE ---------------------------------------------------"
-FAKE_ACAS_GEM_PATH=`bundle show et_fake_acas_server`
+FAKE_ACAS_GEM_PATH=`bundle show et_fake_acas_server | tail -1`
 bash --login -c "cd $FAKE_ACAS_GEM_PATH && /usr/local/rvm/bin/rvm use && bundle install --jobs=4"
 
 if [ -z "$MY_FAKE_ACAS" ]; then


### PR DESCRIPTION
Ignores warnings when using `bundle show` to only provide the last line as atos_gem_path

This should fix the Travis pipeline