### PR TITLE
Update API Docs to Use Upload Key

### DIFF
--- a/docs/et-api.apib
+++ b/docs/et-api.apib
@@ -103,7 +103,7 @@ Creates a respondent response within the system and returns confirmation.
                         "defend_claim_facts":"lorem ipsum defence",
                         "make_employer_contract_claim":true,
                         "claim_information":"lorem ipsum info",
-                        "additional_information_url": "http://s3.et.127.0.0.1.nip.io:3100/etapidirectbucket/1529492014704",
+                        "additional_information_key": "direct_uploads/f42cf743-c9e8-49b8-8a95-00473be8c7b1",
                         "email_receipt": "email@recei.pt"
                     },
                     "uuid": "4611f316-f67a-4ccc-9335-df21408e96f6"


### PR DESCRIPTION
This is from a while ago but we never got round to updating the docs - ET3 is already submitting `additional_information_key` instead of `additional_information_url`.