### PR TITLE
RST-1506: Fix flaky Diversity Religion test

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,29 @@
+# v1.4.0 - ET1 v4.0.0
+**14/11/2018**
+
+## New
+
+* **ET1:** Now with added Welsh!
+
+## Changes
+
+_No other changes_
+
+## Fixes
+
+_No fixes_
+
+## Security
+
+_No security updates_
+
+## Info
+Deployment by Stath
+
+No downtime expected
+
+No risk expected
+
 # v1.3.0 - ATOS v1.2.3, ET3 v2.3.1, Admin v1.6.0 & API v2.5.1
 **12/11/2018**
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -20,9 +20,9 @@ _No security updates_
 ## Info
 Deployment by Stath
 
-No downtime expected
+No downtime expected/observed
 
-No risk expected
+No risk expected/observed
 
 # v1.3.0 - ATOS v1.2.3, ET3 v2.3.1, Admin v1.6.0 & API v2.5.1
 **12/11/2018**

--- a/features/step_definitions/diversity_steps.rb
+++ b/features/step_definitions/diversity_steps.rb
@@ -25,7 +25,7 @@ end
 
 Then("the data is updated in ET Admin system") do  
   within_admin_window do
-    expect(admin_pages.diversity_responses_page).to have_response_for(@diversity), timeout: 30, sleep: 2
+    expect(admin_pages.diversity_responses_page).to have_response_for(@diversity)
   end
 end
 

--- a/test_common/page_objects/admin/diversity_responses_page.rb
+++ b/test_common/page_objects/admin/diversity_responses_page.rb
@@ -10,7 +10,7 @@ module EtFullSystem
             acc[k] = factory_translate(v)
             acc
           end
-          expect {api.admin_diversity_data.symbolize_keys}.to eventually include(expected_data)
+          expect {api.admin_diversity_data.symbolize_keys}.to eventually include(expected_data), timeout: 30, sleep: 2
           true
         end
       end


### PR DESCRIPTION
The timeout for this test was in the wrong place.

We thought this may be a pagination issue but we ruled this out by searching for records that could match the test expectation. Two records that matched were both available on the first page and via the json page so we ruled this out and began investigating whether the issue was a timing issue.

There was an increased timeout and sleep but they were in the wrong place. Moving them into the correct place resolved the problem and the issue has not been replicated since.