### PR TITLE
RST-1511 - Support multiple pdf templates

### DIFF
--- a/features/factories/et3_claimant_factory.rb
+++ b/features/factories/et3_claimant_factory.rb
@@ -61,18 +61,18 @@ FactoryBot.define do
     agree_with_early_conciliation_details 'No'
     disagree_conciliation_reason ''
     continued_employment 'No'
-    agree_with_claimants_description_of_job_or_title 'nil'
+    agree_with_claimants_description_of_job_or_title nil
     disagree_claimants_job_or_title ''
-    agree_with_claimants_hours 'nil'
+    agree_with_claimants_hours nil
     queried_hours ''
-    agree_with_earnings_details 'nil'
+    agree_with_earnings_details nil
     queried_pay_before_tax ''
-    queried_pay_before_tax_period 'nil'
+    queried_pay_before_tax_period nil
     queried_take_home_pay ''
-    queried_take_home_pay_period 'nil'
-    agree_with_claimant_notice 'nil'
+    queried_take_home_pay_period nil
+    agree_with_claimant_notice nil
     disagree_claimant_notice_reason ''
-    agree_with_claimant_pension_benefits 'nil'
+    agree_with_claimant_pension_benefits nil
     disagree_claimant_pension_benefits_reason ''
     defend_claim 'No'
     defend_claim_facts ''

--- a/features/factories/et3_respondent_factory.rb
+++ b/features/factories/et3_respondent_factory.rb
@@ -38,13 +38,13 @@ FactoryBot.define do
     dx_number ''
     contact_number ''
     contact_mobile_number ''
-    contact_preference 'nil'
+    contact_preference nil
     email_address ''
     organisation_employ_gb ''
-    make_employer_contract_claim 'nil'
+    make_employer_contract_claim nil
     claim_information ''
     email_receipt ''
-    disability 'nil'
+    disability nil
     disability_information ''
   end
 end

--- a/features/factories/representative_factory.rb
+++ b/features/factories/representative_factory.rb
@@ -58,7 +58,7 @@ FactoryBot.define do
     have_representative 'No'
     representative_mobile ''
     representative_reference ''
-    representative_contact_preference 'nil'
+    representative_contact_preference nil
     representative_fax ''
     employer_contract_claim ''
   end

--- a/features/step_definitions/et3_atos_export_steps.rb
+++ b/features/step_definitions/et3_atos_export_steps.rb
@@ -18,7 +18,7 @@ Then(/^I can download the ET3 form and validate in PDF format$/) do
   end
   expect { atos_interface }.to eventually have_zip_file_containing(:et3_response_pdf_for, user: @respondent[0], reference: @my_et3_reference), timeout: 45, sleep: 2
   tempfile = atos_interface.download_from_any_zip_to_tempfile(:et3_response_pdf_for, user: @respondent[0], reference: @my_et3_reference)
-  pdf_file = EtFullSystem::Test::FileObjects::Et3PdfFile.new(tempfile)
+  pdf_file = EtFullSystem::Test::FileObjects::Et3PdfFile.new(tempfile, locale: EtFullSystem::Test::Messaging.instance.current_locale)
   expect(pdf_file).to have_correct_contents_for(response: @claimant[0],
     respondent: @respondent[0],
     representative: @representative[0],

--- a/test_common/file_objects/base_pdf_file.rb
+++ b/test_common/file_objects/base_pdf_file.rb
@@ -8,13 +8,7 @@ module EtFullSystem
         include EtFullSystem::Test::I18n
         include ::RSpec::Matchers
 
-        def initalize(tempfile)
-          self.tempfile = tempfile
-        end
-
         private
-
-        attr_accessor :tempfile
 
         def field_values
           @field_values ||= form.fields.inject({}) do |acc, field|
@@ -28,18 +22,7 @@ module EtFullSystem
         end
 
         def form
-          @form ||= PdfForms.new('pdftk').read(tempfile.path)
-        end
-
-        def validate_fields(section:, errors:, indent:)
-          aggregate_failures "Match pdf contents to input data" do
-            yield
-          end
-          true
-        rescue RSpec::Expectations::ExpectationNotMetError => err
-          errors << "Invalid '#{section.to_s.humanize}' section in pdf"
-          errors.concat(err.message.lines.map { |l| "#{'  ' * indent}#{l.gsub(/\n\z/, '')}" })
-          false
+          @form ||= PdfForms.new('pdftk', utf8_fields: true).read(tempfile.path)
         end
 
         def unescape(val)

--- a/test_common/file_objects/et3_pdf_file.rb
+++ b/test_common/file_objects/et3_pdf_file.rb
@@ -1,208 +1,40 @@
-require 'rspec/matchers'
-require 'pdf-forms'
+require_relative 'base'
 module EtFullSystem
   module Test
     module FileObjects
-      # Represents the ET3 PDF file and provides assistance in validating its contents
       class Et3PdfFile < Base # rubocop:disable Metrics/ClassLength
-        include ::RSpec::Matchers
+        include RSpec::Matchers
 
-        def initalize(tempfile)
-          self.tempfile = tempfile
+        def initialize(*args, locale:)
+          super(*args)
+          self.locale = locale
         end
 
         def has_correct_contents_for?(response:, respondent:, representative:, errors: [], indent: 1) # rubocop:disable Naming/PredicateName
-          has_header_for?(respondent, errors: errors, indent: indent) &&
-          has_claimant_for?(response, errors: errors, indent: indent) &&
-          has_respondent_for?(respondent, errors: errors, indent: indent) &&
-          has_acas_for?(response, errors: errors, indent: indent) &&
-          has_employment_details_for?(response, errors: errors, indent: indent) &&
-          has_earnings_for?(response, errors: errors, indent: indent) &&
-          has_response_for?(response, errors: errors, indent: indent) &&
-          has_contract_claim_for?(respondent, errors: errors, indent: indent) &&
-          has_representative_for?(representative, errors: errors, indent: indent) &&
-          has_disability_for?(respondent, errors: errors, indent: indent)
+            Et3PdfFileSection::HeaderSection.new(tempfile, locale: locale).has_contents_for?(respondent: respondent)
+            Et3PdfFileSection::ClaimantSection.new(tempfile, locale: locale).has_contents_for?(response: response)
+            Et3PdfFileSection::RespondentSection.new(tempfile, locale: locale).has_contents_for?(respondent: respondent)
+            Et3PdfFileSection::AcasSection.new(tempfile, locale: locale).has_contents_for?(response: response)
+            Et3PdfFileSection::EmploymentDetailsSection.new(tempfile, locale: locale).has_contents_for?(response: response)
+            Et3PdfFileSection::EarningsSection.new(tempfile, locale: locale).has_contents_for?(response: response)
+            Et3PdfFileSection::ResponseSection.new(tempfile, locale: locale).has_contents_for?(response: response)
+            Et3PdfFileSection::ContractClaimSection.new(tempfile, locale: locale).has_contents_for?(respondent: respondent)
+            Et3PdfFileSection::RepresentativeSection.new(tempfile, locale: locale).has_contents_for?(representative: representative)
+            Et3PdfFileSection::DisabilitySection.new(tempfile, locale: locale).has_contents_for?(respondent: respondent)
         end
 
-        def has_header_for?(respondent, errors: [], indent: 1)
-          validate_fields section: :header, errors: errors, indent: indent do
-            expect(field_values).to include 'case number' => respondent.case_number
-            # Date should be todays date, but in case this has ran through midnight - accept the date from 1 hour ago as well
-            expect(field_values).to include('date_received' => date_for(Time.now)).or(include('date_received' => date_for(1.hour.ago)))
-            expect(field_values).to include 'RTF' => respondent[:rtf_file].blank? ? '' : 'Additional RTF'
-          end
-        end
-
-        def has_claimant_for?(response, errors: [], indent: 1)
-          validate_fields section: :claimant, errors: errors, indent: indent do
-            expect(field_values).to include '1.1' => response.claimants_name
-          end
-        end
-
-        def has_respondent_for?(respondent, errors: [], indent: 1)
-          validate_fields section: :respondent, errors: errors, indent: indent do
-            expect(field_values).to include '2.1' => respondent.name
-            expect(field_values).to include '2.2' => respondent.contact
-            expect(field_values).to include '2.3 number or name' => respondent.building_name
-            expect(field_values).to include '2.3 street' => respondent.street_name
-            expect(field_values).to include '2.3 town city' => respondent.town
-            expect(field_values).to include '2.3 county' => respondent.county
-            expect(field_values).to include '2.3 postcode' => respondent.postcode.tr(' ', '')
-            expect(field_values).to include '2.3 dx number' => respondent.dx_number
-            expect(field_values).to include '2.4 phone number' => respondent.contact_number
-            expect(field_values).to include '2.4 mobile number' => respondent.contact_mobile_number
-            if respondent.contact_preference == 'nil'
-              expect(field_values).to include '2.5' => 'Off'
-            else
-              expect(field_values).to include '2.5' => respondent.contact_preference
-            end
-            expect(field_values).to include '2.6 email address' => respondent.email_address
-            expect(field_values).to include '2.6 fax number' => ''
-            expect(field_values).to include '2.7' => respondent.organisation_employ_gb
-            expect(field_values).to include '2.8' => respondent.organisation_more_than_one_site.downcase
-            expect(field_values).to include '2.9' => ''
-          end
-        end
-
-        def has_acas_for?(response, errors: [], indent: 1)
-          validate_fields section: :acas, errors: errors, indent: indent do
-            expect(field_values).to include 'new 3.1' => response.agree_with_early_conciliation_details
-            expect(field_values).to include 'new 3.1 If no, please explain why' => response.disagree_conciliation_reason
-          end
-        end
-
-        def has_employment_details_for?(response, errors: [], indent: 1)
-          validate_fields section: :employment, errors: errors, indent: indent do
-            expect(field_values).to include '3.1' => response.agree_with_employment_dates.downcase
-            expect(field_values).to include '3.1 employment started' => response.employment_start
-            expect(field_values).to include '3.1 employment end' => response.employment_end
-            expect(field_values).to include '3.1 disagree' => response.disagree_employment
-            expect(field_values).to include '3.2' => response.continued_employment.downcase
-
-            if response.agree_with_claimants_description_of_job_or_title == 'nil'
-              expect(field_values).to include '3.3' => 'Off'
-            else
-            expect(field_values).to include '3.3' => response.agree_with_claimants_description_of_job_or_title.downcase
-            end
-          end
-        end
-
-        def has_earnings_for?(response, errors: [], indent: 1)
-          validate_fields section: :earnings, errors: errors, indent: indent do
-            if response.agree_with_claimants_hours == 'nil'
-             expect(field_values).to include '4.1' => 'Off'
-             expect(field_values).to include '4.2' => 'Off'
-             expect(field_values).to include '4.4 tick box' => 'Off'
-             expect(field_values).to include '4.3 tick box' => 'Off'
-             expect(field_values).to include '4.3 tick box' => 'Off'
-             expect(field_values).to include '4.2 normal take-home pay tick box' => 'Off'
-             expect(field_values).to include '4.2 pay before tax tick box' => 'Off'
-            else
-              expect(field_values).to include '4.1' => response.agree_with_claimants_hours.downcase
-              expect(field_values).to include '4.2' => response.agree_with_earnings_details.downcase
-              expect(field_values).to include '4.4 tick box' => response.agree_with_claimant_pension_benefits.downcase
-              expect(field_values).to include '4.3 tick box' => response.agree_with_claimant_notice.downcase
-              expect(field_values).to include '4.3 tick box' => response.agree_with_claimant_notice.downcase
-              expect(field_values).to include '4.2 normal take-home pay tick box' => response.queried_take_home_pay_period.downcase
-              expect(field_values).to include '4.2 pay before tax tick box' => response.queried_pay_before_tax_period.downcase
-            end
-            expect(field_values).to include '4.1 if no' => decimal_for(response.queried_hours)
-            expect(field_values).to include '4.2 pay before tax' => decimal_for(response.queried_pay_before_tax)
-            expect(field_values).to include '4.2 normal take-home pay' => decimal_for(response.queried_take_home_pay)
-            expect(field_values).to include '4.3 if no' => response.disagree_claimant_notice_reason
-            expect(field_values).to include '4.4 if no' => response.disagree_claimant_pension_benefits_reason
-          end
-        end
-
-        def has_response_for?(response, errors: [], indent: 1)
-          validate_fields section: :response, errors: errors, indent: indent do
-            expect(field_values).to include '5.1 tick box' => response.defend_claim.downcase
-            expect(field_values).to include '5.1 if yes' => response.defend_claim_facts
-          end
-        end
-
-        def has_contract_claim_for?(respondent, errors: [], indent: 1)
-          validate_fields section: :contract_claim, errors: errors, indent: indent do
-            if respondent.make_employer_contract_claim == 'nil'
-            expect(field_values).to include '6.2 tick box' => 'Off'
-            else
-              expect(field_values).to include '6.2 tick box' => respondent.make_employer_contract_claim.downcase
-            end
-            expect(field_values).to include '6.3' => respondent.claim_information
-          end
-        end
-
-        def has_representative_for?(representative, errors: [], indent: 1)
-          return has_no_representative?(errors: errors, indent: indent) if representative.nil?
-          address = representative[:address_attributes]
-          validate_fields section: :representative, errors: errors, indent: indent do
-            expect(field_values).to include '7.1' => representative.name
-            expect(field_values).to include '7.2' => representative.organisation_name
-            expect(field_values).to include '7.3 number or name' => representative.building
-            expect(field_values).to include '7.3 street' => representative.street
-            expect(field_values).to include '7.3 town city' => representative.locality
-            expect(field_values).to include '7.3 county' => representative.county
-            expect(field_values).to include '7.3 postcode' => representative.post_code.tr(' ', '')
-            expect(field_values).to include '7.4' => representative.dx_number
-            expect(field_values).to include '7.5 phone number' => representative.telephone_number
-            expect(field_values).to include '7.6' => representative.representative_mobile
-            expect(field_values).to include '7.7' => representative.representative_reference
-            if representative.representative_contact_preference == 'nil'
-              expect(field_values).to include '7.8 tick box' => 'Off'
-            else
-              expect(field_values).to include '7.8 tick box' => representative.representative_contact_preference.downcase
-            end
-            expect(field_values).to include '7.9' => ''
-            expect(field_values).to include '7.10' => representative.representative_fax
-          end
-        end
-
-        def has_disability_for?(respondent, errors: [], indent: 1)
-          validate_fields section: :disability, errors: errors, indent: indent do
-            if respondent.disability == 'nil'
-              expect(field_values).to include '8.1 tick box' => 'Off'
-            else
-              expect(field_values).to include '8.1 tick box' => respondent.disability.downcase
-            end
-            expect(field_values).to include '8.1 if yes' => respondent.disability_information
-          end
+        def has_correct_contents_from_db_for?(response:, errors: [], indent: 1)
+          respondent = response.respondent.as_json(include: :address).symbolize_keys
+          representative = response.representative.try(:as_json, include: :address).try(:symbolize_keys)
+          respondent[:address_attributes] = respondent.delete(:address).symbolize_keys
+          representative[:address_attributes] = representative.delete(:address).symbolize_keys unless representative.nil?
+          response = response.as_json.symbolize_keys.merge(additional_information_key: response.additional_information_rtf_file? ? 'canbeanything' : nil)
+          has_correct_contents_for?(response: response, respondent: respondent, representative: representative, errors: errors, indent: indent)
         end
 
         private
 
-        attr_accessor :tempfile
-
-        def field_values
-          @field_values ||= form.fields.inject({}) do |acc, field|
-            acc[field.name] = field.value
-            acc
-          end
-        end
-
-        def form
-          @form ||= PdfForms.new('pdftk').read(tempfile.path)
-        end
-
-        def validate_fields(section:, errors:, indent:)
-          aggregate_failures "Match pdf contents to input data" do
-            yield
-          end
-          true
-        rescue RSpec::Expectations::ExpectationNotMetError => err
-          errors << "Invalid '#{section.to_s.humanize}' section in pdf"
-          errors.concat(err.message.lines.map { |l| "#{'  ' * indent}#{l.gsub(/\n\z/, '')}" })
-          false
-        end
-
-        def date_for(date)
-          return date.strftime('%d/%m/%Y') if date.is_a?(Date) || date.is_a?(Time) || date.is_a?(DateTime)
-          Time.zone.parse(date).strftime('%d/%m/%Y')
-        end
-
-        def decimal_for(number)
-          number.to_s
-        end
-
+        attr_accessor :locale
       end
     end
   end

--- a/test_common/file_objects/et3_pdf_file/acas_section.rb
+++ b/test_common/file_objects/et3_pdf_file/acas_section.rb
@@ -1,0 +1,18 @@
+require_relative './base'
+module EtFullSystem
+  module Test
+    module FileObjects
+      module Et3PdfFileSection
+        class AcasSection < ::EtFullSystem::Test::FileObjects::Et3PdfFileSection::Base
+          def has_contents_for?(response:)
+            expected_values = {
+              agree: response[:agree_with_early_conciliation_details] == 'Yes',
+              disagree_explanation: response[:disagree_conciliation_reason] || ''
+            }
+            expect(mapped_field_values).to include(expected_values)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test_common/file_objects/et3_pdf_file/base.rb
+++ b/test_common/file_objects/et3_pdf_file/base.rb
@@ -1,0 +1,89 @@
+require 'rspec/matchers'
+require 'pdf-forms'
+require_relative '../base_pdf_file'
+module EtFullSystem
+  module Test
+    module FileObjects
+      # Represents the ET3 PDF file and provides assistance in validating its contents
+      module Et3PdfFileSection
+        class Base < ::EtFullSystem::Test::FileObjects::BasePdfFile
+          UndefinedField = Object.new
+
+          def initialize(*args, locale:)
+            super(*args)
+            self.locale = locale
+          end
+
+          private
+
+          attr_accessor :locale
+
+          def i18n_section
+            self.class.name.demodulize.underscore.gsub(/_section\z/, '')
+          end
+
+          def mapped_field_values
+            return @mapped_field_values if defined?(@mapped_field_values)
+            lookup = t("response_pdf_fields.#{i18n_section}", locale: locale)
+            @mapped_field_values = lookup.inject({}) do |acc, (key, value)|
+              v = mapped_value(value, key: key)
+              acc[key.to_sym] = v unless v === UndefinedField
+              acc
+            end
+          end
+
+          def mapped_value(value,  key:)
+            if value.is_a?(Hash) && !value.key?(:field_name)
+              value.inject({}) do |acc, (inner_key, inner_value)|
+                v = mapped_value(inner_value, key: inner_key)
+                acc[inner_key] = v unless v === UndefinedField
+                acc
+              end
+            elsif value.is_a?(Hash) && value[:field_name] === false
+              UndefinedField
+            else
+              field_value_for(value, key: key)
+            end
+          end
+
+          def field_value_for(value, key:)
+            if value.key?(:select_values)
+              raw = raw_value_from_pdf(value)
+              ret = value[:select_values].detect { |(key, v)|  v == raw }.try(:[], 0)
+              return true if ret == :true || ret === true
+              return false if ret == :false || ret === false
+              return ret.to_s if ret
+              return nil if raw == value[:unselected_value]
+              raise "Invalid value - '#{raw}' is not in the selected_values list or the unselected_value for field '#{key}' for section #{self.class.name}"
+            else
+              field_values[value[:field_name]]
+            end
+          end
+
+          def raw_value_from_pdf(value)
+            value[:field_name].is_a?(Array) ? value[:field_name].map { |f| field_values[f] } : field_values[value[:field_name]]
+          end
+
+
+          def date_for(date)
+            return date.strftime('%d/%m/%Y') if date.is_a?(Date) || date.is_a?(Time) || date.is_a?(DateTime)
+            Time.zone.parse(date).strftime('%d/%m/%Y')
+          end
+
+          def decimal_for(number)
+            number.to_s
+          end
+
+          def encode_value_for_pdftk(value)
+            value.gsub(/â/, '&#226;')
+          end
+
+          def tri_state(value)
+            return nil if value.nil?
+            value == 'Yes'
+          end
+        end
+      end
+    end
+  end
+end

--- a/test_common/file_objects/et3_pdf_file/claimant_section.rb
+++ b/test_common/file_objects/et3_pdf_file/claimant_section.rb
@@ -1,0 +1,17 @@
+require_relative './base'
+module EtFullSystem
+  module Test
+    module FileObjects
+      module Et3PdfFileSection
+        class ClaimantSection < ::EtFullSystem::Test::FileObjects::Et3PdfFileSection::Base
+          def has_contents_for?(response:)
+            expected_values = {
+              claimants_name: response.claimants_name || ''
+            }
+            expect(mapped_field_values).to include(expected_values)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test_common/file_objects/et3_pdf_file/contract_claim_section.rb
+++ b/test_common/file_objects/et3_pdf_file/contract_claim_section.rb
@@ -1,0 +1,18 @@
+require_relative './base'
+module EtFullSystem
+  module Test
+    module FileObjects
+      module Et3PdfFileSection
+        class ContractClaimSection < ::EtFullSystem::Test::FileObjects::Et3PdfFileSection::Base
+          def has_contents_for?(respondent:)
+            expected_values = {
+              make_employer_contract_claim: respondent[:make_employer_contract_claim] == 'Yes',
+              information: respondent[:claim_information] || ''
+            }
+            expect(mapped_field_values).to include(expected_values)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test_common/file_objects/et3_pdf_file/disability_section.rb
+++ b/test_common/file_objects/et3_pdf_file/disability_section.rb
@@ -1,0 +1,18 @@
+require_relative './base'
+module EtFullSystem
+  module Test
+    module FileObjects
+      module Et3PdfFileSection
+        class DisabilitySection < ::EtFullSystem::Test::FileObjects::Et3PdfFileSection::Base
+          def has_contents_for?(respondent:)
+            expected_values = {
+              has_disability: tri_state(respondent[:disability]),
+              information: respondent[:disability_information] || ''
+            }
+            expect(mapped_field_values).to include(expected_values)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test_common/file_objects/et3_pdf_file/earnings_section.rb
+++ b/test_common/file_objects/et3_pdf_file/earnings_section.rb
@@ -1,0 +1,27 @@
+require_relative './base'
+module EtFullSystem
+  module Test
+    module FileObjects
+      module Et3PdfFileSection
+        class EarningsSection < ::EtFullSystem::Test::FileObjects::Et3PdfFileSection::Base
+          def has_contents_for?(response:)
+            expected_values = {
+              agree_with_hours: tri_state(response[:agree_with_claimants_hours]),
+              correct_hours: decimal_for(response[:queried_hours]),
+              agree_with_earnings: tri_state(response[:agree_with_earnings_details]),
+              correct_pay_before_tax: decimal_for(response[:queried_pay_before_tax]),
+              correct_pay_before_tax_period: response[:queried_pay_before_tax_period],
+              correct_take_home_pay: decimal_for(response[:queried_take_home_pay]),
+              correct_take_home_pay_period: response[:queried_take_home_pay_period],
+              agree_with_notice_period: tri_state(response[:agree_with_claimant_notice]),
+              disagree_notice_period_reason: response[:disagree_claimant_notice_reason] || '',
+              agree_with_pension_benefits: tri_state(response[:agree_with_claimant_pension_benefits]),
+              disagree_pension_benefits_reason: response[:disagree_claimant_pension_benefits_reason] || ''
+            }
+            expect(mapped_field_values).to include(expected_values)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test_common/file_objects/et3_pdf_file/employment_details_section.rb
+++ b/test_common/file_objects/et3_pdf_file/employment_details_section.rb
@@ -1,0 +1,23 @@
+require_relative './base'
+module EtFullSystem
+  module Test
+    module FileObjects
+      module Et3PdfFileSection
+        class EmploymentDetailsSection < ::EtFullSystem::Test::FileObjects::Et3PdfFileSection::Base
+          def has_contents_for?(response:)
+            expected_values = {
+              agree_with_dates: response[:agree_with_employment_dates] == 'Yes',
+              employment_start: response[:employment_start],
+              employment_end: response[:employment_end],
+              disagree_with_dates_reason: response[:disagree_employment] || '',
+              continuing: response[:continued_employment] == 'Yes',
+              agree_with_job_title: tri_state(response[:agree_with_claimants_description_of_job_or_title]),
+              correct_job_title: response[:disagree_claimants_job_or_title]
+            }
+            expect(mapped_field_values).to include(expected_values)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test_common/file_objects/et3_pdf_file/header_section.rb
+++ b/test_common/file_objects/et3_pdf_file/header_section.rb
@@ -1,0 +1,27 @@
+require_relative './base'
+module EtFullSystem
+  module Test
+    module FileObjects
+      module Et3PdfFileSection
+        class HeaderSection < ::EtFullSystem::Test::FileObjects::Et3PdfFileSection::Base
+          def has_contents_for?(respondent:)
+            # @TODO Review this conditional after march 2019 - once the pdf has been sorted, it should have the date_received and rtf fields
+            if locale == 'cy'
+              expected_values = {
+                case_number: respondent.case_number
+              }
+              expect(mapped_field_values).to eql(expected_values)
+            else
+              expected_values = {
+                case_number: respondent.case_number,
+                date_received: date_for(Time.now),
+                rtf: respondent.rtf_file.present?
+              }
+              expect(mapped_field_values).to eql(expected_values).or(include(expected_values.merge(date_received: date_for(1.hour.ago))))
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test_common/file_objects/et3_pdf_file/representative_section.rb
+++ b/test_common/file_objects/et3_pdf_file/representative_section.rb
@@ -1,0 +1,68 @@
+require_relative './base'
+module EtFullSystem
+  module Test
+    module FileObjects
+      module Et3PdfFileSection
+        class RepresentativeSection < ::EtFullSystem::Test::FileObjects::Et3PdfFileSection::Base
+          def has_contents_for?(representative:)
+            return has_no_representative? if representative.nil?
+            expected_values = {
+              name: representative[:name] || '',
+              organisation_name: representative[:organisation_name] || '',
+              address: a_hash_including(
+                building: representative[:building],
+                street: representative[:street],
+                locality: representative[:locality],
+                county: representative[:county],
+                post_code: representative[:post_code].tr(' ', '')
+              ),
+              dx_number: representative[:dx_number] || '',
+              phone_number: representative[:telephone_number] || '',
+              mobile_number: representative[:representative_mobile] || '',
+              reference: representative[:representative_reference] || '',
+              contact_preference: representative[:representative_contact_preference]&.downcase,
+              fax_number: representative[:representative_fax] || ''
+            }
+            # @TODO Re add the code below once the email address is being filled in
+            #               email_address: representative[:email_address] || '',
+            expect(mapped_field_values).to include(expected_values)
+          end
+
+          private
+
+          def empty_address_attributes
+            {
+              building: '',
+              street: '',
+              locality: '',
+              county: '',
+              post_code: ''
+            }
+          end
+
+          def has_no_representative?
+            expected_values = {
+              name: '',
+              organisation_name: '',
+              address: a_hash_including(
+                building: '',
+                street: '',
+                locality: '',
+                county: '',
+                post_code: ''
+              ),
+              dx_number: '',
+              phone_number: '',
+              mobile_number: '',
+              reference: '',
+              contact_preference: nil,
+              email_address: '',
+              fax_number: ''
+            }
+            expect(mapped_field_values).to include(expected_values)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test_common/file_objects/et3_pdf_file/respondent_section.rb
+++ b/test_common/file_objects/et3_pdf_file/respondent_section.rb
@@ -1,0 +1,39 @@
+require_relative './base'
+module EtFullSystem
+  module Test
+    module FileObjects
+      module Et3PdfFileSection
+        class RespondentSection < ::EtFullSystem::Test::FileObjects::Et3PdfFileSection::Base
+          def has_contents_for?(respondent:)
+            respondent = respondent.to_h
+            expected_values = {
+              name: respondent[:name],
+              contact: respondent.fetch(:contact, ''),
+              address: a_hash_including(
+                building: respondent[:building_name],
+                street: respondent[:street_name],
+                locality: respondent[:town],
+                county: respondent[:county],
+                post_code: respondent[:postcode].tr(' ', '')
+              ),
+              address_dx_number: respondent[:dx_number] || '',
+              phone_number: respondent[:contact_number] || '',
+              mobile_number: respondent[:contact_mobile_number] || '',
+              contact_preference: respondent.fetch(:contact_preference, nil),
+              email_address: respondent.fetch(:email_address, ''),
+              fax_number: '',
+              employ_gb: respondent[:organisation_employ_gb].to_s,
+              multi_site_gb: respondent[:organisation_more_than_one_site] == 'Yes',
+              employment_at_site_number: respondent[:employment_at_site_number].to_s
+            }
+            # @TODO Review this conditional after march 2019 - the welsh pdf should have the contact preference field added
+            if locale == 'cy'
+              expected_values.delete(:contact_preference)
+            end
+            expect(mapped_field_values).to match(expected_values)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test_common/file_objects/et3_pdf_file/response_section.rb
+++ b/test_common/file_objects/et3_pdf_file/response_section.rb
@@ -1,0 +1,18 @@
+require_relative './base'
+module EtFullSystem
+  module Test
+    module FileObjects
+      module Et3PdfFileSection
+        class ResponseSection < ::EtFullSystem::Test::FileObjects::Et3PdfFileSection::Base
+          def has_contents_for?(response:)
+            expected_values = {
+              defend_claim: response[:defend_claim] == 'Yes',
+              defend_claim_facts: response[:defend_claim_facts] || ''
+            }
+            expect(mapped_field_values).to include(expected_values)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test_common/messaging/et3_cy.yml
+++ b/test_common/messaging/et3_cy.yml
@@ -295,3 +295,316 @@ cy:
       download_href: https://www.employmenttribunals.service.gov.uk/form/pdf/141ET3_0414v2.pdf
       more_category_link: More from the Working, jobs and pensions category
       more_category_href: http://gov.uk/browse/working
+  # PDF File lookup
+  response_pdf_fields:
+    header:
+      case_number:
+        field_name: 'Rhif yr'
+      date_received:
+        field_name: false
+      rtf:
+        field_name: false
+    claimant:
+      claimants_name:
+        field_name: 'undefined'
+    respondent:
+      name:
+        field_name: 'undefined_2'
+      contact:
+        field_name: 'undefined_3'
+      address:
+        building:
+          field_name: 'Rhif neu enw'
+        street:
+          field_name: 'Stryd'
+        locality:
+          field_name: 'TrefDinas'
+        county:
+          field_name: 'Sir'
+        post_code:
+          field_name: 'Cod post'
+      address_dx_number:
+        field_name: 'undefined_4'
+      phone_number:
+        field_name: 'Lle gallwn gysylltu â chi yn ystod y dydd'
+      mobile_number:
+        field_name: 'n wahanol'
+      contact_preference:
+        field_name: false
+      email_address:
+        field_name: 'undefined_5'
+      fax_number:
+        field_name: 'undefined_6'
+      employ_gb:
+        field_name: 'sefydliad hwn ym Mhrydain Fawr'
+      multi_site_gb:
+        field_name:
+          - 'Oes'
+          - 'Nac oes'
+        select_values:
+          false:
+            - 'Off'
+            - 'On'
+          true:
+            - 'On'
+            - 'Off'
+        unselected_value:
+          - 'Off'
+          - 'Off'
+      employment_at_site_number:
+        field_name: 'r oedd yr hawlydd yn gweithio'
+    acas:
+      agree:
+        field_name:
+          - 'Ydw'
+          - 'Nac ydw'
+        select_values:
+          false:
+            - 'Off'
+            - 'On'
+          true:
+            - 'On'
+            - 'Off'
+        unselected_value:
+          - 'Off'
+          - 'Off'
+      disagree_explanation:
+        field_name: 'Os bu i chi ateb Nac ydw eglurwch pam er'
+    employment_details:
+      agree_with_dates:
+        field_name:
+          - 'Ydynt'
+          - 'Nac ydynt'
+        select_values:
+          false:
+            - 'Off'
+            - 'On'
+          true:
+            - 'On'
+            - 'Off'
+        unselected_value:
+          - 'Off'
+          - 'Off'
+      employment_start:
+        field_name: 'Pa bryd ddechreuodd ei gyflogaeth'
+      employment_end:
+        field_name: 'Pa bryd ddaeth ei gyflogaeth i ben'
+      disagree_with_dates_reason:
+        field_name: 'n anghytuno gydar dyddiadau'
+      continuing:
+        field_name:
+          - 'Ydy'
+          - 'Nac ydy'
+        select_values:
+          false:
+            - 'Off'
+            - 'On'
+          true:
+            - 'On'
+            - 'Off'
+        unselected_value:
+          - 'Off'
+          - 'Off'
+      agree_with_job_title:
+        field_name:
+          - 'Ydy_2'
+          - 'Nac ydy_2'
+        select_values:
+          false:
+            - 'Off'
+            - 'On'
+          true:
+            - 'On'
+            - 'Off'
+        unselected_value:
+          - 'Off'
+          - 'Off'
+      correct_job_title:
+        field_name: 'n gywir'
+    earnings:
+      agree_with_hours:
+        field_name:
+          - 'Ydynt_2'
+          - 'Nac ydynt_2'
+        select_values:
+          false:
+            - 'Off'
+            - 'On'
+          true:
+            - 'On'
+            - 'Off'
+        unselected_value:
+          - 'Off'
+          - 'Off'
+      correct_hours:
+        field_name: 'n gywir_2'
+      agree_with_earnings:
+        field_name:
+          - 'Ydynt_3'
+          - 'Nac ydynt_3'
+        select_values:
+          false:
+            - 'Off'
+            - 'On'
+          true:
+            - 'On'
+            - 'Off'
+        unselected_value:
+          - 'Off'
+          - 'Off'
+      correct_pay_before_tax:
+        field_name: 'fill_4'
+      correct_pay_before_tax_period:
+        field_name:
+          - 'Wythnosol'
+          - 'Misol'
+        select_values:
+          Monthly:
+            - 'Off'
+            - 'On'
+          Weekly:
+            - 'On'
+            - 'Off'
+        unselected_value:
+          - 'Off'
+          - 'Off'
+      correct_take_home_pay:
+        field_name: 'fill_5'
+      correct_take_home_pay_period:
+        field_name:
+          - 'Wythnosol_2'
+          - 'Misol_2'
+        select_values:
+          Monthly:
+            - 'Off'
+            - 'On'
+          Weekly:
+            - 'On'
+            - 'Off'
+        unselected_value:
+          - 'Off'
+          - 'Off'
+      agree_with_notice_period:
+        field_name:
+          - 'Ydy_3'
+          - 'Nac ydy_3'
+        select_values:
+          false:
+            - 'Off'
+            - 'On'
+          true:
+            - 'On'
+            - 'Off'
+        unselected_value:
+          - 'Off'
+          - 'Off'
+      disagree_notice_period_reason:
+        field_name: 'weithio ei gyfnod o rybudd eglurwch beth'
+      agree_with_pension_benefits:
+        field_name:
+          - 'Ydynt_4'
+          - 'Nac ydynt_4'
+        select_values:
+          false:
+            - 'Off'
+            - 'On'
+          true:
+            - 'On'
+            - 'Off'
+        unselected_value:
+          - 'Off'
+          - 'Off'
+      disagree_pension_benefits_reason:
+        field_name: 'n gywir_3'
+    response:
+      defend_claim:
+        field_name:
+          - 'Ydw_2'
+          - 'Nac ydw_2'
+        select_values:
+          false:
+            - 'Off'
+            - 'On'
+          true:
+            - 'On'
+            - 'Off'
+        unselected_value:
+          - 'Off'
+          - 'Off'
+      defend_claim_facts:
+        field_name: 'Gweler y Canllaw  Defnyddiwch y dudalen wag ar ddiwedd y ffurflen hon os bydd angen'
+    contract_claim:
+      make_employer_contract_claim:
+        field_name: 'Check Box1'
+        select_values:
+          true: 'Yes'
+          false: 'Off'
+      information:
+        field_name: 'gweler y Canllaw am ragor o wybodaeth ynghylch pa fanylion y dylech eu cynnwys'
+    representative:
+      name:
+        field_name: 'ch cynrychioli chi llenwch yr wybodaeth ganlynol os gwelwch yn dda  Byddwn yn cysylltu â'
+      organisation_name:
+        field_name: 'undefined_8'
+      address:
+        building:
+          field_name: 'Rhif neu enw_2'
+        street:
+          field_name: 'Stryd_2'
+        locality:
+          field_name: 'TrefDinas_2'
+        county:
+          field_name: 'Sir_2'
+        post_code:
+          field_name: 'Cod post_2'
+      dx_number:
+        field_name: 'undefined_9'
+      phone_number:
+        field_name: 'undefined_10'
+      mobile_number:
+        field_name: 'undefined_11'
+      reference:
+        field_name: 'Eu cyfeirnod ar gyfer gohebiaeth'
+      contact_preference:
+        field_name:
+          - 'Ebost'
+          - 'Post'
+          - 'Ffacs'
+        select_values:
+          email:
+            - 'On'
+            - 'Off'
+            - 'Off'
+          fax:
+            - 'Off'
+            - 'Off'
+            - 'On'
+          post:
+            - 'Off'
+            - 'On'
+            - 'Off'
+        unselected_value:
+          - 'Off'
+          - 'Off'
+          - 'Off'
+      email_address:
+        field_name: 'undefined_12'
+      fax_number:
+        field_name: 'undefined_13'
+    disability:
+      has_disability:
+        field_name:
+          - 'Oes_2'
+          - 'Nac oes_2'
+        select_values:
+          false:
+            - 'Off'
+            - 'On'
+          true:
+            - 'On'
+            - 'Off'
+        unselected_value:
+          - 'Off'
+          - 'Off'
+      information:
+        field_name: 'gynnwys ar gyfer unrhyw wrandawiadau a'

--- a/test_common/messaging/et3_en.yml
+++ b/test_common/messaging/et3_en.yml
@@ -295,3 +295,205 @@ en:
       download_href: https://www.employmenttribunals.service.gov.uk/form/pdf/141ET3_0414v2.pdf
       more_category_link: More from the Working, jobs and pensions category
       more_category_href: http://gov.uk/browse/working
+  # PDF File Lookups
+  response_pdf_fields:
+    header:
+      case_number:
+        field_name: 'case number'
+      date_received:
+        field_name: 'date_received'
+      rtf:
+        field_name: 'RTF'
+        select_values:
+          true: 'Additional RTF'
+          false: ''
+    claimant:
+      claimants_name:
+        field_name: '1.1'
+    respondent:
+      name:
+        field_name: '2.1'
+      contact:
+        field_name: '2.2'
+      address:
+        building:
+          field_name: '2.3 number or name'
+        street:
+          field_name: '2.3 street'
+        locality:
+          field_name: '2.3 town city'
+        county:
+          field_name: '2.3 county'
+        post_code:
+          field_name: '2.3 postcode'
+      address_dx_number:
+        field_name: '2.3 dx number'
+      phone_number:
+        field_name: '2.4 phone number'
+      mobile_number:
+        field_name: '2.4 mobile number'
+      contact_preference:
+        field_name: '2.5'
+        select_values:
+          email: 'email'
+          post: 'post'
+          fax: 'fax'
+        unselected_value: 'Off'
+      email_address:
+        field_name: '2.6 email address'
+      fax_number:
+        field_name: '2.6 fax number'
+      employ_gb:
+        field_name: '2.7'
+      multi_site_gb:
+        field_name: '2.8'
+        select_values:
+          false: 'no'
+          true: 'yes'
+        unselected_value: 'Off'
+      employment_at_site_number:
+        field_name: '2.9'
+    acas:
+      agree:
+        field_name: 'new 3.1'
+        select_values:
+          false: 'No'
+          true: 'Yes'
+        unselected_value: 'Off'
+      disagree_explanation:
+        field_name: 'new 3.1 If no, please explain why'
+    employment_details:
+      agree_with_dates:
+        field_name: '3.1'
+        select_values:
+          false: 'no'
+          true: 'yes'
+        unselected_value: 'Off'
+      employment_start:
+        field_name: '3.1 employment started'
+      employment_end:
+        field_name: '3.1 employment end'
+      disagree_with_dates_reason:
+        field_name: '3.1 disagree'
+      continuing:
+        field_name: '3.2'
+        select_values:
+          no: 'no'
+          yes: 'yes'
+        unselected_value: 'Off'
+      agree_with_job_title:
+        field_name: '3.3'
+        select_values:
+          false: 'no'
+          true: 'yes'
+        unselected_value: 'Off'
+      correct_job_title:
+        field_name: '3.3 if no'
+    earnings:
+      agree_with_hours:
+        field_name: '4.1'
+        select_values:
+          false: 'no'
+          true: 'yes'
+        unselected_value: 'Off'
+      correct_hours:
+        field_name: '4.1 if no'
+      agree_with_earnings:
+        field_name: '4.2'
+        select_values:
+          false: 'no'
+          true: 'yes'
+        unselected_value: 'Off'
+      correct_pay_before_tax:
+        field_name: '4.2 pay before tax'
+      correct_pay_before_tax_period:
+        field_name: '4.2 pay before tax tick box'
+        select_values:
+          Monthly: 'monthly'
+          Weekly: 'weekly'
+        unselected_value: 'Off'
+      correct_take_home_pay:
+        field_name: '4.2 normal take-home pay'
+      correct_take_home_pay_period:
+        field_name: '4.2 normal take-home pay tick box'
+        select_values:
+          Monthly: 'monthly'
+          Weekly: 'weekly'
+        unselected_value: 'Off'
+      agree_with_notice_period:
+        field_name: '4.3 tick box'
+        select_values:
+          no: 'no'
+          yes: 'yes'
+        unselected_value: 'Off'
+      disagree_notice_period_reason:
+        field_name: '4.3 if no'
+      agree_with_pension_benefits:
+        field_name: '4.4 tick box'
+        select_values:
+          no: 'no'
+          yes: 'yes'
+        unselected_value: 'Off'
+      disagree_pension_benefits_reason:
+        field_name: '4.4 if no'
+    response:
+      defend_claim:
+        field_name: '5.1 tick box'
+        select_values:
+          no: 'no'
+          yes: 'yes'
+        unselected_value: 'Off'
+      defend_claim_facts:
+        field_name: '5.1 if yes'
+    contract_claim:
+      make_employer_contract_claim:
+        field_name: '6.2 tick box'
+        select_values:
+          true: 'yes'
+          false: 'Off'
+      information:
+        field_name: '6.3'
+    representative:
+      name:
+        field_name: '7.1'
+      organisation_name:
+        field_name: '7.2'
+      address:
+        building:
+          field_name: '7.3 number or name'
+        street:
+          field_name: '7.3 street'
+        locality:
+          field_name: '7.3 town city'
+        county:
+          field_name: '7.3 county'
+        post_code:
+          field_name: '7.3 postcode'
+      dx_number:
+        field_name: '7.4'
+      phone_number:
+        field_name: '7.5 phone number'
+      mobile_number:
+        field_name: '7.6'
+      reference:
+        field_name: '7.7'
+      contact_preference:
+        field_name: '7.8 tick box'
+        select_values:
+          email: 'email'
+          fax: 'fax'
+          post: 'post'
+        unselected_value: 'Off'
+      email_address:
+        field_name: '7.9'
+      fax_number:
+        field_name: '7.10'
+    disability:
+      has_disability:
+        field_name: '8.1 tick box'
+        select_values:
+          no: 'no'
+          yes: 'yes'
+        unselected_value: 'Off'
+      information:
+        field_name: '8.1 if yes'

--- a/test_common/page_objects/et3/form_submission_page.rb
+++ b/test_common/page_objects/et3/form_submission_page.rb
@@ -10,7 +10,7 @@ module EtFullSystem
         element :submission_confirmation, :css, '.submission-confirmation'
         element :reference_number, :css, '.reference-number'
         element :submission_date, :css, '.submission-date'
-        element :download_pdf, :css, '.pdf-success'
+        element :download_pdf, :css, '.download-pdf'
         element :return_to_govuk_button, :css, 'a.button.button-start'
         def return
           return_to_govuk_button.click

--- a/test_common/page_objects/et3/form_submission_page.rb
+++ b/test_common/page_objects/et3/form_submission_page.rb
@@ -10,7 +10,7 @@ module EtFullSystem
         element :submission_confirmation, :css, '.submission-confirmation'
         element :reference_number, :css, '.reference-number'
         element :submission_date, :css, '.submission-date'
-        element :download_pdf, :css, '.download-pdf'
+        element :download_pdf, :css, '.pdf-success'
         element :return_to_govuk_button, :css, 'a.button.button-start'
         def return
           return_to_govuk_button.click


### PR DESCRIPTION
This PR allows the pdf reading code to read multiple pdf templates.  This is currently used for welsh translation so when ET3 is done in welsh, it selects a welsh pdf template.

The 'ET3 PDF' file object is now completely different.  It works in the same way as the ET1 pdf file object - using translation to map the randomly named "fields" in the pdf to a normalized name for the test code to use.  For example, the case_number field in english is called "case number" in the english pdf and 'Rhif yr' in the welsh one.  My guess is that the pdf authors dont care about the field names, so for now it is going to be up to us to map them.  

Hopefully we can change that for the future though