### PR TITLE
Ignore certificate errors in chrome

### DIFF
--- a/test_common/capybara/capybara_driver_helper.rb
+++ b/test_common/capybara/capybara_driver_helper.rb
@@ -23,6 +23,7 @@ end
 Capybara.register_driver :chromedriver do |app|
   options = Selenium::WebDriver::Chrome::Options.new
   options.add_argument('--no-sandbox')
+  options.add_argument('--ignore-certificate-errors')
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
 end
 
@@ -30,6 +31,7 @@ Capybara.register_driver :chromedriver_headless do |app|
   options = Selenium::WebDriver::Chrome::Options.new
   options.add_argument('--no-sandbox')
   options.add_argument('--headless')
+  options.add_argument('--ignore-certificate-errors')
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
 end
 


### PR DESCRIPTION
Ignore certificate errors in chrome - allowing us to run tests against new azure environments before certificates are sorted