### PR TITLE
Relaxes the query to find the "export claims job"

### DIFF
--- a/test_common/page_objects/admin/job_sidekiq_cron_page.rb
+++ b/test_common/page_objects/admin/job_sidekiq_cron_page.rb
@@ -8,7 +8,7 @@ module EtFullSystem
         end
 
         section :jobs, :xpath, cron_jobs_xpath do
-          section :export_claims, :xpath, XPath.generate {|x| x.descendant(:tr)[x.child(:td)[x.child(:b)[x.string.n.is('export_claims_job')]]]} do
+          section :export_claims, :xpath, XPath.generate {|x| x.descendant(:tr)[x.child(:td)[x.string.n.contains('export_claims_job')]]} do
             element :enqueue_button, :css, 'input[value="Enqueue Now"]'
             def run
               enqueue_button.click


### PR DESCRIPTION
Relaxes the query to find the "export claims job" in the sidekiq cron page.  This is because the latest gem for sidekiq-cron (arriving very very soon in admin) puts a link around the text, so the old query would not find it because it was too specific.