### PR TITLE
Rst 1877 pdf delay

### DIFF
--- a/features/step_definitions/admin_acas_steps.rb
+++ b/features/step_definitions/admin_acas_steps.rb
@@ -78,7 +78,7 @@ end
 
 Then("I can see who has downloaded ACAS certificate {string}") do |string|
   within_admin_window do
-    api = EtFullSystem::Test::AdminApi.new
+    api = EtFullSystem::Test::AdminApi.new atos_interface: atos_interface
     acas_details_from_log = api.acas_certificate_logs_api.select { |a| a['certificate_number'] == "#{@certificate.number}"}[0]
     expect(@certificate.number).to eq(acas_details_from_log['certificate_number'])
     expect(@certificate.user_id).to eq(acas_details_from_log["#{::EtFullSystem::Test::Configuration.admin_username}"])

--- a/features/step_definitions/et1_atos_export_steps.rb
+++ b/features/step_definitions/et1_atos_export_steps.rb
@@ -1,77 +1,47 @@
 Then(/^I can download the form and validate in PDF format$/) do
-  within_admin_window do
-    api = EtFullSystem::Test::AdminApi.new
-    expect { api.claimants_api }.to eventually include(a_hash_including(first_name: @claimant[0].dig(:first_name))), timeout: 45, sleep: 2
-    admin_pages.jobs_page.run_export_claims_cron_job
-  end
-  expect { atos_interface }.to eventually have_zip_file_containing(:et1_claim_pdf_for, user: @claimant[0]), timeout: 45, sleep: 2
-  expect(atos_interface.download_from_any_zip_to_tempfile(:et1_claim_pdf_for, user: @claimant[0])).to match_et1_pdf_for(claim: @claim, claimants: @claimant, representative: @representative.first, respondents: @respondent, employment: @employment)
+  api = EtFullSystem::Test::AdminApi.new atos_interface: atos_interface
+  zip_file = api.atos_zip_file_for_claim(claim_application_reference: @claim_application_reference)
+  expect(zip_file.download_file(:et1_claim_pdf_for, user: @claimant[0])).to match_et1_pdf_for(claim: @claim, claimants: @claimant, representative: @representative.first, respondents: @respondent, employment: @employment)
 end
 
 Then(/^I can download the form and validate in TXT format$/) do
-  within_admin_window do
-    api = EtFullSystem::Test::AdminApi.new
-    expect { api.claimants_api }.to eventually include(a_hash_including(first_name: @claimant[0].dig(:first_name))), timeout: 45, sleep: 2
-    admin_pages.jobs_page.run_export_claims_cron_job
-  end
-  expect { atos_interface }.to eventually have_zip_file_containing(:et1_claim_txt_for, user: @claimant[0]), timeout: 45, sleep: 2
-  expect(atos_interface.download_from_any_zip(:et1_claim_txt_for, user: @claimant[0])).to match_text_schema calculated_claim_matchers(user: @claimant[0], representative: @representative[0], respondents: @respondent, employment: @employment)
+  api = EtFullSystem::Test::AdminApi.new atos_interface: atos_interface
+  zip_file = api.atos_zip_file_for_claim(claim_application_reference: @claim_application_reference)
+  expect(zip_file.download_file(:et1_claim_txt_for, user: @claimant[0])).to match_text_schema calculated_claim_matchers(user: @claimant[0], representative: @representative[0], respondents: @respondent, employment: @employment)
 end
 
 Then(/^I can download the uploaded CSV data and validate in TXT format$/) do
-  within_admin_window do
-    api = EtFullSystem::Test::AdminApi.new
-    expect { api.claimants_api }.to eventually include(a_hash_including(first_name: @claimant[0].dig(:first_name))), timeout: 45, sleep: 2
-    admin_pages.jobs_page.run_export_claims_cron_job
-  end
-  expect { atos_interface }.to eventually have_zip_file_containing(:et1a_claim_txt_for, user: @claimant[0]), timeout: 45, sleep: 2
-  expect(atos_interface.download_from_any_zip(:et1a_claim_txt_for, user: @claimant[0])).to match_text_schema calculated_et1a_claim_matchers(user: @claimant[0], respondents: @respondent)
+  api = EtFullSystem::Test::AdminApi.new atos_interface: atos_interface
+  zip_file = api.atos_zip_file_for_claim(claim_application_reference: @claim_application_reference)
+  expect(zip_file.download_file(:et1a_claim_txt_for, user: @claimant[0])).to match_text_schema calculated_et1a_claim_matchers(user: @claimant[0], respondents: @respondent)
 end
 
 Then(/^I can download the uploaded CSV data and validate in CSV format$/) do
-  within_admin_window do
-    api = EtFullSystem::Test::AdminApi.new
-    expect { api.claimants_api }.to eventually include(a_hash_including(first_name: @claimant[0].dig(:first_name))), timeout: 45, sleep: 2
-    admin_pages.jobs_page.run_export_claims_cron_job
-  end
-  expect { atos_interface }.to eventually have_zip_file_containing(:et1_claim_csv_for, user: @claimant[0]), timeout: 45, sleep: 2
+  api = EtFullSystem::Test::AdminApi.new atos_interface: atos_interface
+  zip_file = api.atos_zip_file_for_claim(claim_application_reference: @claim_application_reference)
+  expect(zip_file.download_file(:et1_claim_csv_for, user: @claimant[0])).to be_present
 end
 
 Then(/^I can download the form and validate in Rich Text format$/) do
-  within_admin_window do
-    api = EtFullSystem::Test::AdminApi.new
-    expect { api.claimants_api }.to eventually include(a_hash_including(first_name: @claimant[0].dig(:first_name))), timeout: 45, sleep: 2
-    admin_pages.jobs_page.run_export_claims_cron_job
-  end
-  expect { atos_interface }.to eventually have_zip_file_containing(:et1_claim_rtf_for, user: @claimant[0]), timeout: 45, sleep: 2
+  api = EtFullSystem::Test::AdminApi.new atos_interface: atos_interface
+  zip_file = api.atos_zip_file_for_claim(claim_application_reference: @claim_application_reference)
+  expect(zip_file.download_file(:et1_claim_rtf_for, user: @claimant[0])).to be_present
 end
 
 Then(/^I can download the form and validate the TXT file contained 3 employers details$/) do
-  within_admin_window do
-    api = EtFullSystem::Test::AdminApi.new
-    expect { api.claimants_api }.to eventually include(a_hash_including(first_name: @claimant[0].dig(:first_name))), timeout: 45, sleep: 2
-    admin_pages.jobs_page.run_export_claims_cron_job
-  end
-  expect { atos_interface }.to eventually have_zip_file_containing(:et1_claim_txt_for, user: @claimant[0]), timeout: 45, sleep: 2
-  expect(atos_interface.download_from_any_zip(:et1_claim_txt_for, user: @claimant[0])).to match_text_schema calculated_claim_matchers(user: @claimant[0], representative: @representative[0], respondents: @respondent, employment: @employment)
+  api = EtFullSystem::Test::AdminApi.new atos_interface: atos_interface
+  zip_file = api.atos_zip_file_for_claim(claim_application_reference: @claim_application_reference)
+  expect(zip_file.download_file(:et1_claim_txt_for, user: @claimant[0])).to match_text_schema calculated_claim_matchers(user: @claimant[0], representative: @representative[0], respondents: @respondent, employment: @employment)
 end
 
 Then("I can download the form and validate that the filename starts with {string}") do |string|
-  within_admin_window do
-    api = EtFullSystem::Test::AdminApi.new
-    expect { api.claimants_api }.to eventually include(a_hash_including(first_name: @claimant[0].dig(:first_name))), timeout: 45, sleep: 2
-    admin_pages.jobs_page.run_export_claims_cron_job
-  end
-  expect { atos_interface }.to eventually have_zip_file_containing(:et1_filename_start_with, user: @claimant[0], local_office: string), timeout: 45, sleep: 2
-  expect(atos_interface.download_from_any_zip_to_tempfile(:et1_claim_pdf_for, user: @claimant[0])).to match_et1_pdf_for(claim: @claim, claimants: @claimant, representative: @representative.first, respondents: @respondent, employment: @employment)
+  api = EtFullSystem::Test::AdminApi.new atos_interface: atos_interface
+  zip_file = api.atos_zip_file_for_claim(claim_application_reference: @claim_application_reference)
+  expect(zip_file.download_file(:et1_claim_pdf_for, user: @claimant[0])).to match_et1_pdf_for(claim: @claim, claimants: @claimant, representative: @representative.first, respondents: @respondent, employment: @employment)
 end
 
 Then("I can download the form from the secondary queue and that the filename starts with {string}") do |string|
-  within_admin_window do
-    api = EtFullSystem::Test::AdminApi.new
-    expect { api.claimants_api }.to eventually include(a_hash_including(first_name: @claimant[0].dig(:first_name))), timeout: 45, sleep: 2
-    admin_pages.jobs_page.run_export_claims_cron_job
-  end
-  expect { atos_secondary_interface }.to eventually have_zip_file_containing(:et1_filename_start_with, user: @claimant[0], local_office: string), timeout: 45, sleep: 2
-  expect(atos_secondary_interface.download_from_any_zip_to_tempfile(:et1_claim_pdf_for, user: @claimant[0])).to match_et1_pdf_for(claim: @claim, claimants: @claimant, representative: @representative.first, respondents: @respondent, employment: @employment), timeout: 45, sleep: 2
+  api = EtFullSystem::Test::AdminApi.new atos_interface: atos_secondary_interface
+  zip_file = api.atos_zip_file_for_claim(claim_application_reference: @claim_application_reference)
+  expect(zip_file.download_file(:et1_claim_pdf_for, user: @claimant[0])).to match_et1_pdf_for(claim: @claim, claimants: @claimant, representative: @representative.first, respondents: @respondent, employment: @employment), timeout: 45, sleep: 2
 end

--- a/features/step_definitions/et1_claim_steps.rb
+++ b/features/step_definitions/et1_claim_steps.rb
@@ -12,7 +12,8 @@ When /^the completed form is submitted$/ do
   et1_answer_claim_outcome_questions
   et1_answer_more_about_the_claim_questions
   et1_submit_claim
-  log_event :et1_claim_created, @claimant
+  @claim_application_reference = et1_claim_submitted.claim_number
+  log_event :et1_claim_submitted, application_reference: @claim_application_reference
 end
 
 When /^I submit a completed ET1 form$/ do
@@ -35,5 +36,6 @@ When /^I submit a completed ET1 form$/ do
   et1_answer_more_about_the_claim_questions
 
   et1_submit_claim
-  log_event :et1_claim_created, @claimant
+  @claim_application_reference = et1_claim_submitted.claim_number
+  log_event :et1_claim_submitted, application_reference: @claim_application_reference
 end

--- a/features/step_definitions/et1_claim_steps.rb
+++ b/features/step_definitions/et1_claim_steps.rb
@@ -12,8 +12,6 @@ When /^the completed form is submitted$/ do
   et1_answer_claim_outcome_questions
   et1_answer_more_about_the_claim_questions
   et1_submit_claim
-  @claim_application_reference = et1_claim_submitted.claim_number
-  log_event :et1_claim_submitted, application_reference: @claim_application_reference
 end
 
 When /^I submit a completed ET1 form$/ do
@@ -36,6 +34,4 @@ When /^I submit a completed ET1 form$/ do
   et1_answer_more_about_the_claim_questions
 
   et1_submit_claim
-  @claim_application_reference = et1_claim_submitted.claim_number
-  log_event :et1_claim_submitted, application_reference: @claim_application_reference
 end

--- a/features/step_definitions/et3_atos_export_steps.rb
+++ b/features/step_definitions/et3_atos_export_steps.rb
@@ -1,23 +1,14 @@
 Then(/^I can download the ET3 form and validate in TXT format$/) do
-  within_admin_window do
-    api = EtFullSystem::Test::AdminApi.new
-    expect { api.respondents_api }.to eventually include a_hash_including(name: @respondent[0].dig(:name))
-    admin_pages.jobs_page.run_export_claims_cron_job
-  end
-  expect { atos_interface }.to eventually have_zip_file_containing(:et3_response_txt_for, user: @respondent[0], reference: @my_et3_reference), timeout: 45, sleep: 2
-  expect(atos_interface.download_from_any_zip(:et3_response_txt_for, user: @respondent[0], reference: @my_et3_reference)).to match_text_schema calculated_response_matchers(user: @claimant[0], representative: @representative[0], respondent: @respondent[0])
+  api = EtFullSystem::Test::AdminApi.new atos_interface: atos_interface
+  zip_file = api.atos_zip_file_for(reference: @my_et3_reference)
+  expect(zip_file.download_file(:et3_response_txt_for, user: @respondent[0], reference: @my_et3_reference)).to match_text_schema calculated_response_matchers(user: @claimant[0], representative: @representative[0], respondent: @respondent[0])
 end
 
 
 Then(/^I can download the ET3 form and validate in PDF format$/) do
-  errors = []
-  within_admin_window do
-    api = EtFullSystem::Test::AdminApi.new
-    expect { api.respondents_api }.to eventually include(a_hash_including(name: @respondent[0].dig(:name))), timeout: 45, sleep: 2
-    admin_pages.jobs_page.run_export_claims_cron_job
-  end
-  expect { atos_interface }.to eventually have_zip_file_containing(:et3_response_pdf_for, user: @respondent[0], reference: @my_et3_reference), timeout: 45, sleep: 2
-  tempfile = atos_interface.download_from_any_zip_to_tempfile(:et3_response_pdf_for, user: @respondent[0], reference: @my_et3_reference)
+  api = EtFullSystem::Test::AdminApi.new atos_interface: atos_interface
+  zip_file = api.atos_zip_file_for(reference: @my_et3_reference)
+  tempfile = zip_file.download_file(:et3_response_pdf_for, user: @respondent[0], reference: @my_et3_reference)
   pdf_file = EtFullSystem::Test::FileObjects::Et3PdfFile.new(tempfile, locale: EtFullSystem::Test::Messaging.instance.current_locale)
   expect(pdf_file).to have_correct_contents_for(response: @claimant[0],
     respondent: @respondent[0],
@@ -26,21 +17,15 @@ Then(/^I can download the ET3 form and validate in PDF format$/) do
 end
 
 Then("I can download the ET3 form from the secondary atos and validate that the filename starts with '99'") do
-  within_admin_window do
-    api = EtFullSystem::Test::AdminApi.new
-    expect { api.respondents_api }.to eventually include a_hash_including(name: @respondent[0].dig(:name))
-    admin_pages.jobs_page.run_export_claims_cron_job
-  end
-  expect { atos_secondary_interface }.to eventually have_zip_file_containing(:et3_filename_start_with, user: @respondent[0], reference: @my_et3_reference, local_postcode: '99'), timeout: 45, sleep: 2
+  api = EtFullSystem::Test::AdminApi.new atos_interface: atos_secondary_interface
+  zip_file = api.atos_zip_file_for(reference: @my_et3_reference)
+  expect(zip_file.download_file(:et3_filename_start_with, user: @respondent[0], reference: @my_et3_reference, local_postcode: '99')).to be_present
 end
 
 Then("I can download the ET3 form and validate that the filename starts with {string}") do |string|
-  within_admin_window do
-    api = EtFullSystem::Test::AdminApi.new
-    expect { api.respondents_api }.to eventually include a_hash_including(name: @respondent[0].dig(:name))
-    admin_pages.jobs_page.run_export_claims_cron_job
-  end
-  expect { atos_interface }.to eventually have_zip_file_containing(:et3_filename_start_with, user: @respondent[0], reference: @my_et3_reference, local_postcode: string), timeout: 45, sleep: 2
+  api = EtFullSystem::Test::AdminApi.new atos_interface: atos_interface
+  zip_file = api.atos_zip_file_for(reference: @my_et3_reference)
+  expect(zip_file.download_file(:et3_filename_start_with, user: @respondent[0], reference: @my_et3_reference, local_postcode: string)).to be_present
 end
 
 Then("it will be forwarded to the Office address {string}") do |string|
@@ -52,11 +37,7 @@ Then("phone number {string}") do |string|
 end
 
 Then(/^I can download the ET3 form and validate in RTF format$/) do
-  export = lambda do
-    within_admin_window do
-      admin_pages.jobs_page.run_export_claims_cron_job
-    end
-    atos_interface
-  end
-  expect(export).to eventually have_zip_file_containing(:et3_response_rtf_for, user: @respondent[0], reference: @my_et3_reference), timeout: 45, sleep: 2
+  api = EtFullSystem::Test::AdminApi.new atos_interface: atos_interface
+  zip_file = api.atos_zip_file_for(reference: @my_et3_reference)
+  expect(zip_file.download_file(:et3_response_rtf_for, user: @respondent[0], reference: @my_et3_reference)).to be_present
 end

--- a/test_common/api/admin.rb
+++ b/test_common/api/admin.rb
@@ -20,8 +20,9 @@ module EtFullSystem
       end
 
       def login
+        return if logged_in?
         get_token
-        request(:post, "#{url}/login",
+        resp = request(:post, "#{url}/login",
           headers: {
             'Content-Type' => 'application/x-www-form-urlencoded'
           },
@@ -34,6 +35,9 @@ module EtFullSystem
             },
             authenticity_token: csrf_token
           })
+        raise "An error occured trying to login" unless resp.success?
+
+        self.logged_in = true
       end
 
       def respondents_api
@@ -104,9 +108,15 @@ module EtFullSystem
             sleep(sleep)
           end
         end
+      rescue Timeout::Error
+        raise "An ATOS zip file for reference #{reference} was not found"
       end
 
       private
+
+      def logged_in?
+        logged_in
+      end
 
       def find_claim(claim_application_reference:, timeout: 30, sleep: 0.5)
         login
@@ -144,7 +154,7 @@ module EtFullSystem
         last_response
       end
       
-      attr_accessor :cookies_hash, :last_response, :csrf_token, :sidekiq_authenticity_token, :sidekiq_cron_form_url, :atos_interface
+      attr_accessor :cookies_hash, :last_response, :csrf_token, :sidekiq_authenticity_token, :sidekiq_cron_form_url, :atos_interface, :logged_in
     end
   end
 end

--- a/test_common/api/admin.rb
+++ b/test_common/api/admin.rb
@@ -129,7 +129,7 @@ module EtFullSystem
           end
         end
       rescue Timeout::Error
-        Raise "The claim with application_reference #{application_reference} was not stored in the API"
+        Raise "The claim with application_reference #{claim_application_reference} was not stored in the API"
 
       end
 

--- a/test_common/atos_interface.rb
+++ b/test_common/atos_interface.rb
@@ -52,7 +52,7 @@ module EtFullSystem
       def download_from_zip_to_tempfile(zip_filename, identifier, **args)
         tempfile = Tempfile.new
         filename = find_file_in_zip(zip_filename, identifier, **args)
-        raise "No zip file containing #{identifier} - #{args} was found in zip file #{zip_filename}" unless filename.present?
+        raise "No file #{identifier} was found in zip file #{zip_filename} - The args were #{args}" unless filename.present?
         all_filenames_in_all_zip_files.extract_from_zip(zip_filename, filename, to: File.dirname(tempfile.path), as: File.basename(tempfile.path))
         tempfile.rewind
         tempfile

--- a/test_common/helpers/et1/et1_claim_helper.rb
+++ b/test_common/helpers/et1/et1_claim_helper.rb
@@ -75,6 +75,8 @@ module EtFullSystem
 
       def et1_submit_claim
         et1_submission_page.submit_claim
+        @claim_application_reference = et1_claim_submitted.claim_number
+        log_event :et1_claim_submitted, application_reference: @claim_application_reference
       end
 
       def et1_submit_your_feedback

--- a/test_common/matchers/match_text_schema.rb
+++ b/test_common/matchers/match_text_schema.rb
@@ -31,8 +31,8 @@ module EtFullSystem
       def actual_as_array(actual)
         case actual
         when String then actual.lines("\r\n").map {|l| l.gsub(/\r\n\z/, '')}
-        when IO then actual.read.lines("\r\n").map {|l| l.gsub(/\r\n\z/, '')}
-        else raise "Must be a string or a file containing the data to be read"
+        when IO, Tempfile then actual.read.lines("\r\n").map {|l| l.gsub(/\r\n\z/, '')}
+        else raise "Must be a string or a file containing the data to be read - a #{actual.class.name} was provided"
         end
       end
 

--- a/test_common/page_objects/admin/diversity_responses_page.rb
+++ b/test_common/page_objects/admin/diversity_responses_page.rb
@@ -5,7 +5,7 @@ module EtFullSystem
         set_url "/diversity_responses"
 
         def has_response_for?(data)
-          api = EtFullSystem::Test::AdminApi.new
+          api = EtFullSystem::Test::AdminApi.new atos_interface: atos_interface
           expected_data = data.to_h.inject({}) do |acc, (k,v)|
             acc[k] = factory_translate(v)
             acc

--- a/test_common/page_objects/et1/claim_submitted.rb
+++ b/test_common/page_objects/et1/claim_submitted.rb
@@ -114,6 +114,10 @@ module EtFullSystem
             expect(main_content.submission_details.attachments).to have_no_attachments
           end
         end
+
+        def claim_number
+          main_content.callout_confirmation.answer.text
+        end
       end
     end
   end


### PR DESCRIPTION
This PR allows the tests to work with up to a 30 second delay for the pdf to be generated etc..

It achieve this, the code to run the cron job and test for the files has been made much more efficient (the cron job does not need an admin window anymore) allowing both the cron job and the file checking to be part of the wait loop.

Also, the file checking is now super robust - it records the reference from the final page of either et1 or et3 - then it uses the admin API (inn the case of ET1) to look up the claim and get the proper reference.  It then searches for a zip filename containing files for this reference number.  
The zip file has a new object which has methods to download individual files.