### PR TITLE
Rst 2847

### DIFF
--- a/features/et1/et1_claimant_details.feature
+++ b/features/et1/et1_claimant_details.feature
@@ -36,6 +36,10 @@ Feature:
     When I submit an invalid date of birth for claimant details page
     Then I should see an invalid error message for date of birth claimant details page
 
+  Scenario: Invalid allow video attendance error
+    When I submit an invalid allow video attendance for claimant details page
+    Then I should see an invalid error message for allow video attendance claimant details page
+
   # Scenario: Save and complete later
   #   When I click on Save and complete later
   #   Then I should be able to return to where I was left off

--- a/features/et3/form_submission_page.feature
+++ b/features/et3/form_submission_page.feature
@@ -13,6 +13,3 @@ Background: ET3 form submission page
 
   Scenario: Download PDF
     Then I can download a PDF of my application
-
-  Scenario: Return to gov.uk
-    Then I can return to gov.uk

--- a/features/factories/claimant_factory.rb
+++ b/features/factories/claimant_factory.rb
@@ -11,6 +11,7 @@ FactoryBot.define do
     email_address { "sivvoy.taing@hmcts.net" }
     correspondence { :"simple_form.options.claimant.contact_preference.email" }
     memorable_word { 'password' }
+    allow_video_attendance { :"simple_form.options.claimant.allow_video_attendance.yes" }
 
     trait :contact_by_post do
       correspondence { :"simple_form.options.claimant.contact_preference.post" }

--- a/features/factories/et3_claimant_factory.rb
+++ b/features/factories/et3_claimant_factory.rb
@@ -77,6 +77,7 @@ FactoryBot.define do
     defend_claim {:"questions.defend_claim.no.label"}
     defend_claim_facts {''}
     agree_with_employment_dates {:"questions.agree_with_employment_dates.yes.label"}
+    allow_video_attendance { :"questions.allow_video_attendance.no.label" }
     employment_start {''}
     employment_end {''}
     disagree_employment {''}

--- a/features/factories/et3_respondent_factory.rb
+++ b/features/factories/et3_respondent_factory.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
     county {"london"}
     postcode {"wc1 1aa"}
     organisation_more_than_one_site {:"questions.organisation_more_than_one_site.no.label"}
+    allow_video_attendance { :"questions.allow_video_attendance.yes.label" }
   end
 
   factory :et3_dummy_data, class: OpenStruct do
@@ -57,5 +58,6 @@ FactoryBot.define do
     email_receipt {''}
     disability {nil}
     disability_information {''}
+    allow_video_attendance { :"questions.allow_video_attendance.no.label" }
   end
 end

--- a/features/factories/respondent_factory.rb
+++ b/features/factories/respondent_factory.rb
@@ -3,7 +3,6 @@ require 'faker'
 FactoryBot.define do
   factory :respondent, class: OpenStruct do
     name { Faker::Company.name }
-
     trait :work_address do
         work_building {'101'}
         work_street {'Petty France'}

--- a/features/step_definitions/et1_claimant_details_page_steps.rb
+++ b/features/step_definitions/et1_claimant_details_page_steps.rb
@@ -66,3 +66,11 @@ end
 Then("I should see an invalid error message for date of birth claimant details page") do
   expect(et1_claimant_details_page.has_correct_invalid_error_message_for_dob?).to be true
 end
+
+When("I submit an invalid allow video attendance for claimant details page") do
+  et1_claimant_details_page.save_and_continue.click
+end
+
+Then("I should see an invalid error message for allow video attendance claimant details page") do
+  expect(et1_claimant_details_page.has_correct_invalid_error_message_for_allow_video_attendance?).to be true
+end

--- a/test_common/file_objects/et1_pdf_file/base.rb
+++ b/test_common/file_objects/et1_pdf_file/base.rb
@@ -48,7 +48,7 @@ module EtFullSystem
               return ret if ret == true || ret == false
               return ret.to_s if ret
               if value[:unselected_value].is_a? Array
-                return nil if value[:unselected_value].include?(raw)
+                return nil if value[:unselected_value].include?(raw) || value[:unselected_value] == raw
               else
                 return nil if value[:unselected_value] == raw
               end  

--- a/test_common/file_objects/et1_pdf_file/earnings_and_benefits_section.rb
+++ b/test_common/file_objects/et1_pdf_file/earnings_and_benefits_section.rb
@@ -21,7 +21,7 @@ module EtFullSystem
                 pay_before_tax: pay_tax(employment.try(:pay_before_tax), employment.pay_before_tax_type.to_s.split('.').last),
                 pay_after_tax: pay_tax(employment.try(:pay_after_tax), employment.pay_after_tax_type.to_s.split('.').last),
                 paid_for_notice_period: nil,
-                # @TODO Re add - notice_period: notice_period(employment.notice_period, employment.notice_period_type),
+                notice_period: notice_period(employment.notice_period, employment.notice_period_type),
                 employers_pension_scheme: employers_pension_scheme(employment),
                 benefits: employment.try(:benefits)
               }

--- a/test_common/file_objects/et1_pdf_file/earnings_and_benefits_section.rb
+++ b/test_common/file_objects/et1_pdf_file/earnings_and_benefits_section.rb
@@ -21,7 +21,7 @@ module EtFullSystem
                 pay_before_tax: pay_tax(employment.try(:pay_before_tax), employment.pay_before_tax_type.to_s.split('.').last),
                 pay_after_tax: pay_tax(employment.try(:pay_after_tax), employment.pay_after_tax_type.to_s.split('.').last),
                 paid_for_notice_period: nil,
-                notice_period: notice_period(employment.notice_period, employment.notice_period_type),
+                # @TODO Re add - notice_period: notice_period(employment.notice_period, employment.notice_period_type),
                 employers_pension_scheme: employers_pension_scheme(employment),
                 benefits: employment.try(:benefits)
               }

--- a/test_common/file_objects/et1_pdf_file/respondents_details_section.rb
+++ b/test_common/file_objects/et1_pdf_file/respondents_details_section.rb
@@ -27,7 +27,7 @@ module EtFullSystem
                     post_code: post_code_for(respondents.first.work_post_code, optional: true) || '',
                     telephone_number: respondents.first.work_telephone_number || ''
                 },
-                # @TODO Re add - additional_respondents: respondents.length > 1 ? true : false,
+                additional_respondents: respondents.length > 1 ? true : false,
                 respondent2: {
                     name: title_for(respondents[1].try(:name), optional: true) || '',
                     address: {

--- a/test_common/file_objects/et1_pdf_file/respondents_details_section.rb
+++ b/test_common/file_objects/et1_pdf_file/respondents_details_section.rb
@@ -27,7 +27,7 @@ module EtFullSystem
                     post_code: post_code_for(respondents.first.work_post_code, optional: true) || '',
                     telephone_number: respondents.first.work_telephone_number || ''
                 },
-                additional_respondents: respondents.length > 1 ? true : false, 
+                # @TODO Re add - additional_respondents: respondents.length > 1 ? true : false,
                 respondent2: {
                     name: title_for(respondents[1].try(:name), optional: true) || '',
                     address: {

--- a/test_common/file_objects/et1_pdf_file/your_details_section.rb
+++ b/test_common/file_objects/et1_pdf_file/your_details_section.rb
@@ -5,43 +5,27 @@ module EtFullSystem
       module Et1PdfFileSection
         class YourDetailsSection < EtFullSystem::Test::FileObjects::Et1PdfFileSection::Base
           def has_contents_for?(claimant:)
-            if claimant.gender == :"simple_form.options.claimant.gender.prefer_not_to_say"
-              expected_values = {
-                title: title_for(claimant.title)&.camelcase,
-                first_name: claimant.first_name,
-                last_name: claimant.last_name,
-                dob_day: claimant.date_of_birth.split('/')[0],
-                dob_month: claimant.date_of_birth.split('/')[1],
-                dob_year: claimant.date_of_birth.split('/')[2],
-                gender: nil,
-                building: claimant.building,
-                street: claimant.street,
-                locality: claimant.locality,
-                county: claimant.county,
-                post_code: post_code_for(claimant.post_code),
-                telephone_number: claimant.telephone_number,
-                alternative_telephone_number: claimant.alternative_telephone_number,
-                email_address: claimant.correspondence.to_s =~ /email\z/ ? claimant.email_address : '',
-                correspondence: contact_preference_for(claimant.correspondence)
-              }
-            else expected_values = {
-                title: title_for(claimant.title)&.camelcase,
-                first_name: claimant.first_name,
-                last_name: claimant.last_name,
-                dob_day: claimant.date_of_birth.split('/')[0],
-                dob_month: claimant.date_of_birth.split('/')[1],
-                dob_year: claimant.date_of_birth.split('/')[2],
-                gender: gender_for(claimant.gender, optional: true),
-                building: claimant.building,
-                street: claimant.street,
-                locality: claimant.locality,
-                county: claimant.county,
-                post_code: post_code_for(claimant.post_code),
-                telephone_number: claimant.telephone_number,
-                alternative_telephone_number: claimant.alternative_telephone_number,
-                email_address: claimant.correspondence.to_s =~ /email\z/ ? claimant.email_address : '',
-                correspondence: contact_preference_for(claimant.correspondence)
+            expected_values = {
+              title: title_for(claimant.title)&.camelcase,
+              first_name: claimant.first_name,
+              last_name: claimant.last_name,
+              dob_day: claimant.date_of_birth.split('/')[0],
+              dob_month: claimant.date_of_birth.split('/')[1],
+              dob_year: claimant.date_of_birth.split('/')[2],
+              gender: gender_for(claimant.gender, optional: true),
+              building: claimant.building,
+              street: claimant.street,
+              locality: claimant.locality,
+              county: claimant.county,
+              post_code: post_code_for(claimant.post_code),
+              telephone_number: claimant.telephone_number,
+              alternative_telephone_number: claimant.alternative_telephone_number,
+              email_address: claimant.correspondence.to_s =~ /email\z/ ? claimant.email_address : '',
+              correspondence: contact_preference_for(claimant.correspondence),
+              allow_video_attendance: claimant.allow_video_attendance.to_s.split('.').last == 'yes'
             }
+            if claimant.gender == :"simple_form.options.claimant.gender.prefer_not_to_say"
+              expected_values[:gender] = nil
             end
             expect(mapped_field_values).to include expected_values
           end

--- a/test_common/file_objects/et3_pdf_file/respondent_section.rb
+++ b/test_common/file_objects/et3_pdf_file/respondent_section.rb
@@ -20,6 +20,7 @@ module EtFullSystem
               phone_number: respondent[:contact_number] || '',
               mobile_number: respondent[:contact_mobile_number] || '',
               contact_preference: contact_preference(respondent[:contact_preference]),
+              allow_video_attendance: respondent[:allow_video_attendance].to_s.split('.')[-2] == 'yes',
               email_address: respondent.fetch(:email_address, ''),
               fax_number: '',
               employ_gb: respondent[:organisation_employ_gb].to_s,

--- a/test_common/helpers/et3/et3_response_helper.rb
+++ b/test_common/helpers/et3/et3_response_helper.rb
@@ -30,6 +30,7 @@ module EtFullSystem
         respondents_details_page.contact_number_question.set(user.contact_number)
         respondents_details_page.contact_mobile_number_question.set(user.contact_mobile_number)
         respondents_details_page.contact_preference_question.set_for(user)
+        respondents_details_page.allow_video_attendance_question.set_for(user)
         respondents_details_page.organisation_more_than_one_site_question.set_for(user)
         respondents_details_page.organisation_employ_gb_question.set(user.organisation_employ_gb)
 
@@ -44,6 +45,7 @@ module EtFullSystem
         respondents_details_page.street_question.set(user.street_name)
         respondents_details_page.town_question.set(user.town)
         respondents_details_page.postcode_question.set(user.postcode)
+        respondents_details_page.allow_video_attendance_question.set_for(user)
         respondents_details_page.organisation_more_than_one_site_question.set_for(user)
 
         respondents_details_page.next

--- a/test_common/messaging/et1_cy.yml
+++ b/test_common/messaging/et1_cy.yml
@@ -27,6 +27,9 @@ cy:
         contact_preference:
           email: E-bost
           post: Post
+        allow_video_attendance:
+          'yes': 'Gallaf'
+          'no': 'Na allaf'
         title:
           mr: Mr
           mrs: Mrs
@@ -160,6 +163,7 @@ cy:
         address_country: Gwlad
         applying_for_remission: "Ydych chi eisiau gwneud cais am help i dalu eich ffi (a elwir yn \"help i dalu ffioedd\")?"
         contact_preference: "Y ffordd orau i anfon gohebiaeth atoch (yr hawlydd)"
+        allow_video_attendance: "A allech chi gymryd rhan mewn gwrandawiad drwy fideo? (angen mynediad i'r rhyngrwyd)."
         _destroy: 'Dileu''r hawlydd yma'
         gender: Rhywedd
 
@@ -319,6 +323,7 @@ cy:
         has_representative: Rhywun sydd wedi cytuno i'ch cynrychioli (er enghraifft, i baratoi eich achos a/neu gweithredu ar eich rhan os bydd gwrandawiad).
         applying_for_remission: Efallai na fydd rhaid i chi dalu ffi os nad oes gennych lawer o gynilion a'ch bod yn cael budd-daliadau neu ar incwm isel. Ydw i'n gymwys i gael help?
         contact_preference: "Noder, os oes gennych gynrychiolydd (ee cyfreithiwr), yna fe anfonir pob gohebiaeth atynt"
+        allow_video_attendance: "Ceir rhagor o fanylion am wrandawiadau fideo drwy ddilyn y ddolen a ganlyn: https://www.gov.uk/guidance/hmcts-telephone-and-video-hearings-during-coronavirus-outbreak"
         address_county: "Ee os Llundain, Llundain Fwyaf; os Manceinion, Manceinion Fwyaf"
       claimants:
         address_county: "Ee os Llundain, Llundain Fwyaf; os Manceinion, Manceinion Fwyaf"
@@ -779,6 +784,8 @@ cy:
               blank: Dywedwch p'un a ydych angen cymorth yn y gwrandawiad tribiwnlys
             contact_preference:
               blank: "Dywedwch p'un a hoffech i ohebiaeth gael ei hanfon at yr hawlydd drwy'r post neu e-bost"
+            allow_video_attendance:
+              blank: "Dywedwch p’un a fyddech yn gallu mynychu gwrandawiad trwy gyswllt fideo"
             address_building:
               blank: Rhowch rif neu enw adeilad cyfeiriad yr hawlydd
             address_street:
@@ -899,90 +906,159 @@ cy:
   claim_pdf_fields:
     your_details:
       title:
-        field_name: 1.1 title tick boxes
+        field_name:
+          - Check Box1
+          - Check Box2
+          - Check Box3
+          - Check Box4
         select_values:
-          Miss: miss
-          Mr: mr
-          Mrs: mrs
-          Ms: ms
-        unselected_value: 'Off'
+          Miss:
+            - 'Off'
+            - 'Off'
+            - 'Yes'
+            - 'Off'
+          Mr:
+            - 'Yes'
+            - 'Off'
+            - 'Off'
+            - 'Off'
+          Mrs:
+            - 'Off'
+            - 'Yes'
+            - 'Off'
+            - 'Off'
+          Ms:
+            - 'Off'
+            - 'Off'
+            - 'Off'
+            - 'Yes'
+        unselected_value:
+          - 'Off'
+          - 'Off'
+          - 'Off'
+          - 'Off'
       first_name:
-        field_name: 1.2 first names
+        field_name: undefined
       last_name:
-        field_name: 1.3 surname
+        field_name: undefined_2
       dob_day:
-        field_name: 1.4 DOB day
+        field_name: undefined_3
       dob_month:
-        field_name: 1.4 DOB month
+        field_name: undefined_4
       dob_year:
-        field_name: 1.4 DOB year
+        field_name: undefined_5
       gender:
-        field_name: 1.4 gender
+        field_name:
+          - Check Box6
+          - Check Box5
         select_values:
-          female: female
-          male: male
-        unselected_value: 'Off'
+          female:
+            - 'Off'
+            - 'Yes'
+          male:
+            - 'Yes'
+            - 'Off'
+        unselected_value:
+          - 'Off'
+          - 'Off'
       building:
-        field_name: 1.5 number
+        field_name: Rhifneuenw
       street:
-        field_name: 1.5 street
+        field_name: Stryd
       locality:
-        field_name: 1.5 town city
+        field_name: nas
       county:
-        field_name: 1.5 county
+        field_name: r
       post_code:
-        field_name: 1.5 postcode
+        field_name: Cod post
       telephone_number:
-        field_name: 1.6 phone number
+        field_name: 'tu â chi yn ystod y dydd'
       alternative_telephone_number:
-        field_name: 1.7 mobile number
+        field_name: 'Rhifffônsymudolosywnwahanol'
       email_address:
-        field_name: 1.9 email
+        field_name: dogfennaun electronig
       correspondence:
-        field_name: 1.8 tick boxes
+        field_name:
+          - Check Box7
+          - Check Box8
+          - Check Box9
         select_values:
-          email: email
-          fax: fax
-          post: post
-        unselected_value: 'Off'
+          email:
+            - 'Yes'
+            - 'Off'
+            - 'Off'
+          post:
+            - 'Off'
+            - 'Yes'
+            - 'Off'
+          fax:
+            - 'Off'
+            - 'Off'
+            - 'Yes'
+        unselected_value:
+          - 'Off'
+          - 'Off'
+          - 'Off'
+      allow_video_attendance:
+        field_name:
+          - Check Box10
+          - Check Box11
+        select_values:
+          false:
+            - 'Off'
+            - 'Yes'
+          true:
+            - 'Yes'
+            - 'Off'
+        unselected_value:
+          - 'Off'
+          - 'Off'
     respondents_details:
       name:
-        field_name: '2.1'
+        field_name: wchychwanegurhagoroatebwyr
       address:
         building:
-          field_name: 2.2 number
+          field_name: Rhifneuenw_2
         street:
-          field_name: 2.2 street
+          field_name: Stryd_2
         locality:
-          field_name: 2.2 town city
+          field_name: nas_2
         county:
-          field_name: 2.2 county
+          field_name: r_2
         post_code:
-          field_name: 2.2 postcode
+          field_name: Cod post_2
         telephone_number:
-          field_name: 2.2 phone number
+          field_name: f ffon
       acas:
         have_acas:
-          field_name: Check Box1
+          field_name:
+            - Check Box12
+            - Check Box13
           select_values:
-            true: 'Yes'
-            false: 'no'
-          unselected_value: 'Off'
+            true:
+              - 'Yes'
+              - 'Off'
+            false:
+              - 'Off'
+              - 'Yes'
+          unselected_value:
+            - 'Off'
+            - 'Off'
         acas_number:
-          field_name: Text2
+          field_name: 'cynnar'
       different_address:
         building:
-          field_name: 2.3 number
+          field_name: Rhifneuenw_3
         street:
-          field_name: 2.3 street
+          field_name: Stryd_3
         locality:
-          field_name: 2.3 town city
+          field_name: nas_3
         county:
-          field_name: 2.3 county
+          field_name: r_3
         post_code:
-          field_name: 2.3 postcode
+          field_name: Cod post_3
         telephone_number:
-          field_name: 2.3 phone number
+          field_name: undefined_7
       additional_respondents:
         field_name: 2.4 tick box
         select_values:
@@ -990,385 +1066,470 @@ cy:
           true: 'yes'
       respondent2:
         name:
-          field_name: 2.4 R2 name
+          field_name: undefined_8
         address:
           building:
-            field_name: 2.4 R2 number
+            field_name: Rhifneuenw_4
           street:
-            field_name: 2.4 R2 street
+            field_name: Stryd_4
           locality:
-            field_name: 2.4 R2 town
+            field_name: nas_4
           county:
-            field_name: 2.4 R2 county
+            field_name: r_4
           post_code:
-            field_name: 2.4 R2 postcode
+            field_name: Cod post_4
           telephone_number:
-            field_name: 2.4 R2 phone number
+            field_name: undefined_9
         acas:
           have_acas:
-            field_name: Check Box8
+            field_name:
+              - Check Box18
+              - Check Box19
             unselected_value:
               - 'Off'
-              - null
+              - 'Off'
             select_values:
-              true: 'Yes'
-              false: 'no'
+              true:
+                - 'Yes'
+                - 'Off'
+              false:
+                - 'Off'
+                - 'Yes'
           acas_number:
-            field_name: Text9
+            field_name: cynnar_2
       respondent3:
         name:
-          field_name: 2.4 R3 name
+          field_name: undefined_10
         address:
           building:
-            field_name: 2.4 R3 number
+            field_name: Rhifneuenw_5
           street:
-            field_name: 2.4 R3 street
+            field_name: Stryd_5
           locality:
-            field_name: 2.4 R3 town city
+            field_name: nas_5
           county:
-            field_name: 2.4 R3 county
+            field_name: r_5
           post_code:
-            field_name: 2.4 R3 postcode
+            field_name: Cod post_5
           telephone_number:
-            field_name: 2.4 R3 phone number
+            field_name: undefined_11
         acas:
           have_acas:
-            field_name: Check Box15
+            field_name:
+              - Check Box24
+              - Check Box25
             unselected_value:
               - 'Off'
-              - null
+              - 'Off'
             select_values:
-              true: 'Yes'
-              false: 'no'
+              true:
+                - 'Yes'
+                - 'Off'
+              false:
+                - 'Off'
+                - 'Yes'
           acas_number:
-            field_name: Text16
+            field_name: cynnar_3
     multiple_cases:
       have_similar_claims:
-        field_name: 3.1 tick boxes
-        unselected_value: 'Off'
+        field_name:
+          - Check Box31
+          - Check Box30
+        unselected_value:
+          - 'Off'
+          - 'Off'
         select_values:
-          false: 'no'
-          true: 'yes'
+          false:
+            - 'Off'
+            - 'Off'
+          true:
+            - 'Yes'
+            - 'Off'
       other_claimants:
-        field_name: 3.1 if yes
+        field_name: ad gyda
     not_your_employer:
       claim_type:
         field_name: '4.1'
     employment_details:
       job_title:
-        field_name: '5.2'
+        field_name: Nodwch pa swydd yr ydychyr oeddech ynei
       start_date:
-        field_name: 5.1 employment start
+        field_name: ch swydd
       employment_continuing:
-        field_name: 5.1 tick boxes
+        field_name:
+          - Check Box33
+          - Check Box32
         select_values:
-          false: 'no'
-          true: 'yes'
+          false:
+            - 'Off'
+            - 'Yes'
+          true:
+            - 'Yes'
+            - 'Off'
         unselected_value:
           - 'Off'
-          - null
+          - 'Off'
       ended_date:
-        field_name: 5.1 employment end
+        field_name: Os daeth eich swydd i ben pa bryd
       ending_date:
-        field_name: 5.1 not ended
+        field_name: chimewncyfnodrhybuddosydychpabrydy
     earnings_and_benefits:
       average_weekly_hours:
-        field_name: '6.1'
+        field_name: 'tiedig â hi'
       pay_before_tax:
         amount:
-          field_name: 6.2 pay before tax
+          field_name: fill_4
         period:
-          field_name: 6.2 pay before tax tick boxes
+          field_name:
+            - Check Box35
+            - Check Box34
           select_values:
-            weekly: weekly
-            monthly: monthly
+            weekly:
+              - 'Yes'
+              - 'Off'
+            monthly:
+              - 'Off'
+              - 'Yes'
           unselected_value:
             - 'Off'
-            - null
+            - 'Off'
       pay_after_tax:
         amount:
-          field_name: 6.2 normal pay
+          field_name: fill_5
         period:
-          field_name: 6.2 normal pay tick boxes
+          field_name:
+            - Check Box36
+            - Check Box37
           select_values:
-            weekly: weekly
-            monthly: monthly
+            weekly:
+              - 'Yes'
+              - 'Off'
+            monthly:
+              - 'Off'
+              - 'Yes'
           unselected_value:
             - 'Off'
-            - null
+            - 'Off'
       paid_for_notice_period:
-        field_name: 6.3 tick boxes
+        field_name:
+          - Check Box39
+          - Check Box38
+        select_values:
+          false:
+            - 'Off'
+            - 'Yes'
+          true:
+            - 'Yes'
+            - 'off'
         unselected_value:
           - 'Off'
-          - null
-        select_values:
-          false: 'no'
-          true: 'yes'
+          - 'Off'
       notice_period:
         weeks:
-          field_name: 6.3 weeks
+          field_name: wythnos
         months:
-          field_name: 6.3 months
+          field_name: mis
       employers_pension_scheme:
-        field_name: 6.4 tick boxes
+        field_name:
+          - Check Box42
+          - Check Box41
         select_values:
-          false: 'no'
-          true: 'yes'
+          false:
+            - 'Off'
+            - 'Yes'
+          true:
+            - 'Yes'
+            - 'Off'
         unselected_value:
           - 'Off'
-          - null
+          - 'Off'
       benefits:
-        field_name: '6.5'
+        field_name: aybganeich
     what_happened_since:
       have_another_job:
-        field_name: 7.1 tick boxes
+        field_name:
+          - Check Box44
+          - Check Box43
         unselected_value:
           - 'Off'
-          - null
+          - 'Off'
         select_values:
-          false: 'no'
-          true: 'yes'
+          false:
+            - 'Off'
+            - 'Yes'
+          true:
+            - 'Yes'
+            - 'Off'
       start_date:
-        field_name: '7.2'
+        field_name: Nodwch pa bryd ddechreuodd y swydd neu pa
       salary:
-        field_name: '7.3'
+        field_name: fill_6
     type_and_details:
       unfairly_dismissed:
-        field_name: 8.1 unfairly tick box
+        field_name: Check Box45
         select_values:
           false: 'Off'
-          true: 'yes'
+          true: 'Yes'
       discriminated:
-        field_name: 8.1 discriminated
+        field_name: Check Box46
         select_values:
           false: 'Off'
-          true: 'yes'
+          true: 'Yes'
       discriminated_age:
-        field_name: 8.1 age
+        field_name: Check Box55
         select_values:
           false: 'Off'
-          true: 'yes'
+          true: 'Yes'
       discriminated_race:
-        field_name: 8.1 race
+        field_name: Check Box50
         select_values:
           false: 'Off'
-          true: 'yes'
+          true: 'Yes'
       discriminated_gender_reassignment:
-        field_name: 8.1 gender reassignment
+        field_name: Check Box54
         select_values:
           false: 'Off'
-          true: 'yes'
+          true: 'Yes'
       discriminated_disability:
-        field_name: 8.1 disability
+        field_name: Check Box49
         select_values:
           false: 'Off'
-          true: 'yes'
+          true: 'Yes'
       discriminated_pregnancy:
-        field_name: 8.1 pregnancy
+        field_name: Check Box53
         select_values:
           false: 'Off'
-          true: 'yes'
+          true: 'Yes'
       discriminated_marriage:
-        field_name: 8.1 marriage
+        field_name: Check Box48
         select_values:
           false: 'Off'
-          true: 'yes'
+          true: 'Yes'
       discriminated_sexual_orientation:
-        field_name: 8.1 sexual orientation
+        field_name: Check Box52
         select_values:
           false: 'Off'
-          true: 'yes'
+          true: 'Yes'
       discriminated_sex:
-        field_name: 8.1 sex
+        field_name: Check Box47
         select_values:
           false: 'Off'
-          true: 'yes'
+          true: 'Yes'
       discriminated_religion:
-        field_name: 8.1 religion
+        field_name: Check Box51
         select_values:
           false: 'Off'
-          true: 'yes'
+          true: 'Yes'
       claiming_redundancy_payment:
-        field_name: 8.1 redundancy
+        field_name: Check Box56
         select_values:
           false: 'Off'
-          true: 'yes'
+          true: 'Yes'
       owed:
-        field_name: 8.1 owed
+        field_name: Check Box57
         select_values:
           false: 'Off'
-          true: 'yes'
+          true: 'Yes'
       owed_notice_pay:
-        field_name: 8.1 notice pay
+        field_name: Check Box61
         select_values:
           false: 'Off'
-          true: 'yes'
+          true: 'Yes'
       owed_holiday_pay:
-        field_name: 8.1 holiday pay
+        field_name: Check Box60
         select_values:
           false: 'Off'
-          true: 'yes'
+          true: 'Yes'
       owed_arrears_of_pay:
-        field_name: 8.1 arrears of pay
+        field_name: Check Box59
         select_values:
           false: 'Off'
-          true: 'yes'
+          true: 'Yes'
       owed_other_payments:
-        field_name: 8.1 other payments
+        field_name: Check Box58
         select_values:
           false: 'Off'
-          true: 'yes'
+          true: 'Yes'
       other_type_of_claim:
-        field_name: 8.1 another type of claim
+        field_name: Check Box62
         select_values:
           false: 'Off'
-          true: 'yes'
+          true: 'Yes'
       other_type_of_claim_details:
-        field_name: 8.1 other type of claim
+        field_name: NodwchnaturyrhawliadDarper
       claim_description:
-        field_name: '8.2'
+        field_name: Defnyddiwch y ddalen wag ar ddiwedd y ffurflen os bydd angen
     what_do_you_want:
       prefer_re_instatement:
-        field_name: 9.1 old job back
+        field_name: Check Box63
         select_values:
           false: 'Off'
-          true: 'yes'
+          true: 'Yes'
       prefer_re_engagement:
-        field_name: 9.1 another job
+        field_name: Check Box64
         select_values:
           false: 'Off'
-          true: 'yes'
+          true: 'Yes'
       prefer_compensation:
-        field_name: 9.1 compensation
+        field_name: Check Box65
         select_values:
           false: 'Off'
-          true: 'yes'
+          true: 'Yes'
       prefer_recommendation:
-        field_name: 9.1 recommendation
+        field_name: Check Box66
         select_values:
           false: 'Off'
-          true: 'yes'
+          true: 'Yes'
       compensation:
-        field_name: '9.2'
+        field_name: barod rhowch hyn isod os gwelwch yn dda
     information_to_regulators:
       whistle_blowing:
-        field_name: '10.1'
+        field_name: Check Box67
         select_values:
           false: 'Off'
-          true: 'yes'
+          true: 'Yes'
     your_representative:
       name_of_representative:
-        field_name: '11.1'
+        field_name: 'Os oes rhywun wedi cytuno ich cynrychioli chi llenwch yr adran hon Byddwn yn cysylltu âch cynrychiolwr yn unig o hyn ymlaen'
       name_of_organisation:
-        field_name: '11.2'
+        field_name: undefined_12
       building:
-        field_name: 11.3 number
+        field_name: Rhifneuenw_6
       street:
-        field_name: 11.3 street
+        field_name: Stryd_6
       locality:
-        field_name: 11.3 town city
+        field_name: nas_6
       county:
-        field_name: 11.3 county
+        field_name: r_6
       post_code:
-        field_name: 11.3 postcode
+        field_name: Cod post_6
       dx_number:
-        field_name: 11.4 dx number
+        field_name: undefined_13
       telephone_number:
-        field_name: 11.5 phone number
+        field_name: undefined_14
       alternative_telephone_number:
-        field_name: 11.6 mobile number
+        field_name: undefined_15
       reference:
-        field_name: 11.7 reference
+        field_name: rnod ar gyfer gohebiaeth
       email_address:
-        field_name: 11.8 email
+        field_name: undefined_16
       communication_preference:
-        field_name: 11.9 tick boxes
+        field_name:
+          - Check Box70
+          - Check Box69
+          - Check Box68
+        select_values:
+          email:
+            - 'Yes'
+            - 'Off'
+            - 'Off'
+          post:
+            - 'Off'
+            - 'Yes'
+            - 'Off'
+          fax:
+            - 'Off'
+            - 'Off'
+            - 'Yes'
         unselected_value:
           - 'Off'
-          - null
-        select_values:
-          email: email
-          fax: fax
-          post: post
+          - 'Off'
+          - 'Off'
       fax_number:
-        field_name: 11.10 fax number
+        field_name: undefined_17
     disability:
       has_special_needs:
-        field_name: 12.1 tick box
-        unselected_value: 'Off'
+        field_name:
+          - Check Box72
+          - Check Box71
+        unselected_value:
+          - 'Off'
+          - 'Off'
         select_values:
-          false: 'no'
-          true: 'yes'
+          false:
+            - 'Off'
+            - 'Yes'
+          true:
+            - 'Yes'
+            - 'Off'
       special_needs:
-        field_name: 12.1 if yes
+        field_name: gynnwysargyferunrhywwrandawiadaua
     additional_respondents:
       respondent4:
         name:
-          field_name: 13 R4 name
+          field_name: undefined_18
         building:
-          field_name: 13 R4 number
+          field_name: Rhifneuenw_7
         street:
-          field_name: 13 R4 street
+          field_name: Stryd_7
         locality:
-          field_name: 13 R4 town city
+          field_name: nas_7
         county:
-          field_name: 13 R4 county
+          field_name: r_7
         post_code:
-          field_name: 13 R4 postcode
+          field_name: Cod post_7
         telephone_number:
-          field_name: 13 R4 phone number
+          field_name: undefined_19
         have_acas:
-          field_name: Check Box22
+          field_name:
+            - Check Box74
+            - Check Box73
           unselected_value:
             - 'Off'
-            - null
+            - 'Off'
           select_values:
-            true: 'Yes'
-            false: 'no'
+            true:
+              - 'Yes'
+              - 'Off'
+            false:
+              - 'Off'
+              - 'Yes'
         acas_number:
-          field_name: Text23
+          field_name: cynnar_4
       respondent5:
         name:
-          field_name: 13 R5 name
+          field_name: undefined_20
         building:
-          field_name: 13 R5 number
+          field_name: Rhifneuenw_8
         street:
-          field_name: R5 street
+          field_name: Stryd_8
         locality:
-          field_name: R5 town city
+          field_name: nas_8
         county:
-          field_name: R5 county
+          field_name: r_8
         post_code:
-          field_name: R5 postcode
+          field_name: Cod post_8
         telephone_number:
-          field_name: R5 phone number
+          field_name: Dylai bod gan bron bawb y rhif hwn cyn iddynt lenwir
         have_acas:
-          field_name: Check Box29
+          field_name:
+            - Check Box80
+            - Check Box79
           unselected_value:
             - 'Off'
-            - null
+            - 'Off'
           select_values:
-            true: 'Yes'
-            false: 'no'
+            true:
+              - 'Yes'
+              - 'Off'
+            false:
+              - 'Off'
+              - 'Yes'
         acas_number:
-          field_name: Text30
+          field_name: cynnar_5
     final_check:
       satisfied:
-        field_name: 14 satisfied tick box
-        unselected_value: null
-        select_values:
-          false: 'Off'
-          true: 'yes'
+        field_name: '14 satisfied tick box'
     additional_information:
       additional_information:
-        field_name: '15'
+        field_name: wrthym pam
     official_use_only:
       tribunal_office:
-        field_name: 'tribunal office'
+        field_name: Swyddfa Tribiwnlys
       case_number:
-        field_name: 'case number'
+        field_name: Rhif yr achos
       date_received:
-        field_name: 'date received'
+        field_name: ad derbyn
   review:
     submit_claim: "Cyflwyno'r hawliad"
     common:

--- a/test_common/messaging/et1_en.yml
+++ b/test_common/messaging/et1_en.yml
@@ -26,6 +26,9 @@ en:
         contact_preference:
           email: Email
           post: Post
+        allow_video_attendance:
+          'yes': 'Yes'
+          'no': 'No'
         title:
           mr: Mr
           mrs: Mrs
@@ -153,6 +156,7 @@ en:
         address_country: Country
         applying_for_remission: Do you want to get help paying your fee (known as ‘help with fees’)?
         contact_preference: Best way to send correspondence to you (the claimant)
+        allow_video_attendance: Would you be able to take part in a hearing by video? (Requires internet access).
         _destroy: 'Remove this claimant'
 
       additional_claimants:
@@ -279,6 +283,7 @@ en:
         has_representative: "Someone who has agreed to represent you (for example, to prepare your case and/or act on your behalf if there is a hearing)"
         applying_for_remission: "You may not have to pay a fee if you have limited savings and you’re on benefits or a low income. Do I qualify for help?"
         contact_preference: "Note that if you have a representative (eg solicitor), then all future correspondence will be sent to them"
+        allow_video_attendance: "Further details on video hearings can be found on the following link https://www.gov.uk/guidance/hmcts-telephone-and-videohearings-during-coronavirus-outbreak"
         address_county: "Eg if London, Greater London; if Manchester, Greater Manchester"
       claimants:
         address_county: Eg if London, Greater London; if Manchester, Greater Manchester
@@ -732,6 +737,8 @@ en:
               blank: Say whether you require assistance at the tribunal hearing
             contact_preference:
               blank: "Say whether you’d like correspondence to be sent to the claimant by post or email"
+            allow_video_attendance:
+              blank: "Please say whether you would be able to attend a hearing by video"
             address_building:
               blank: "Enter the building number or name from the claimant’s address"
             address_street:
@@ -852,10 +859,10 @@ en:
       title:
         field_name: 1.1 title tick boxes
         select_values:
-          Miss: miss
-          Mr: mr
-          Mrs: mrs
-          Ms: ms
+          Miss: Your details - 1.1 Title - tickbox - Miss
+          Mr: Your details - 1.1 Title - tickbox - Mr
+          Mrs: Your details - 1.1 Title - tickbox - Mrs
+          Ms: Your details - 1.1 Title - tickbox - Ms
         unselected_value: 'Off'
       first_name:
         field_name: 1.2 first names
@@ -896,6 +903,12 @@ en:
           fax: fax
           post: post
         unselected_value: 'Off'
+      allow_video_attendance:
+        field_name: 'Check Box2'
+        select_values:
+          true: 'Yes'
+          false: 'no'
+        unselected_value: 'Off'
     respondents_details:
       name:
         field_name: '2.1'
@@ -935,10 +948,10 @@ en:
         telephone_number:
           field_name: 2.3 phone number
       additional_respondents:
-        field_name: 2.4 tick box
+        field_name: Check Box7
         select_values:
           false: 'Off'
-          true: 'yes'
+          true: 'Yes'
       respondent2:
         name:
           field_name: 2.4 R2 name
@@ -958,9 +971,7 @@ en:
         acas:
           have_acas:
             field_name: Check Box8
-            unselected_value:
-              - 'Off'
-              - null
+            unselected_value: 'Off'
             select_values:
               true: 'Yes'
               false: 'no'
@@ -1251,7 +1262,7 @@ en:
           false: 'no'
           true: 'yes'
       special_needs:
-        field_name: 12.1 if yes
+        field_name: '12.1 if yes'
     additional_respondents:
       respondent4:
         name:

--- a/test_common/messaging/et3_cy.yml
+++ b/test_common/messaging/et3_cy.yml
@@ -38,6 +38,12 @@ cy:
       fax:
         label: Ffacs
         input_label: Rhif ffacs
+    allow_video_attendance:
+      label: A allech chi gymryd rhan mewn gwrandawiad drwy fideo? (angen mynediad i'r rhyngrwyd)
+      'yes':
+        label: Gallaf
+      'no':
+        label: Na allaf
     organisation_employ_gb:
       label: "Faint o bobl sy’n gyflogedig gan y sefydliad hwn ym Mhrydain Fawr? (dewisol)"
     organisation_more_than_one_site:

--- a/test_common/messaging/et3_cy.yml
+++ b/test_common/messaging/et3_cy.yml
@@ -436,315 +436,345 @@ cy:
   response_pdf_fields:
     header:
       case_number:
-        field_name: 'Rhif yr'
+        field_name: Text2
       date_received:
-        field_name: false
+        field_name: Text3
       rtf:
         field_name: false
     claimant:
       claimants_name:
-        field_name: 'undefined'
+        field_name: undefined
     respondent:
       name:
-        field_name: 'undefined_2'
+        field_name: undefined_2
       contact:
-        field_name: 'undefined_3'
+        field_name: undefined_3
       address:
         building:
-          field_name: 'Rhif neu enw'
+          field_name: Rhif neu enw
         street:
-          field_name: 'Stryd'
+          field_name: Stryd
         locality:
-          field_name: 'TrefDinas'
+          field_name: nas
         county:
-          field_name: 'Sir'
+          field_name: r
         post_code:
-          field_name: 'Cod post'
+          field_name: Text13
       address_dx_number:
-        field_name: 'undefined_4'
+        field_name: undefined_5
       phone_number:
-        field_name: 'Lle gallwn gysylltu â chi yn ystod y dydd'
+        field_name: ynystodydydd
       mobile_number:
-        field_name: 'n wahanol'
+        field_name: Rhif ffôn symudol os ywn wahanol
       contact_preference:
-        field_name: false
+        field_name:
+          - Check Box4
+          - Check Box5
+          - Check Box6
+        select_values:
+          email:
+            - 'Yes'
+            - 'Off'
+            - 'Off'
+          post:
+            - 'Off'
+            - 'Yes'
+            - 'Off'
+          fax:
+            - 'Off'
+            - 'Off'
+            - 'Yes'
       email_address:
-        field_name: 'undefined_5'
+        field_name: e
       fax_number:
-        field_name: 'undefined_6'
+        field_name: undefined_6
+      allow_video_attendance:
+        field_name:
+          - Check Box7
+          - Check Box8
+        select_values:
+          yes:
+            - 'Yes'
+            - 'Off'
+          no:
+            - 'Off'
+            - 'Yes'
+        unselected_value:
+          - 'Off'
+          - 'Off'
       employ_gb:
-        field_name: 'sefydliad hwn ym Mhrydain Fawr'
+        field_name: ogedig gan y
       multi_site_gb:
         field_name:
-          - 'Oes'
-          - 'Nac oes'
+          - Check Box10
+          - Check Box9
         select_values:
           false:
             - 'Off'
-            - 'On'
+            - 'Yes'
           true:
-            - 'On'
+            - 'Yes'
             - 'Off'
         unselected_value:
           - 'Off'
           - 'Off'
       employment_at_site_number:
-        field_name: 'r oedd yr hawlydd yn gweithio'
+        field_name: saflebleroeddyrhawlyddyngweithio
     acas:
       agree:
         field_name:
-          - 'Ydw'
-          - 'Nac ydw'
+          - 'Check Box12'
+          - 'Check Box11'
         select_values:
           false:
             - 'Off'
-            - 'On'
+            - 'Yes'
           true:
-            - 'On'
+            - 'Yes'
             - 'Off'
         unselected_value:
           - 'Off'
           - 'Off'
       disagree_explanation:
-        field_name: 'Os bu i chi ateb Nac ydw eglurwch pam er'
+        field_name: Text4
     employment_details:
       agree_with_dates:
         field_name:
-          - 'Ydynt'
-          - 'Nac ydynt'
+          - Check Box13
+          - Check Box14
         select_values:
           false:
             - 'Off'
-            - 'On'
+            - 'Yes'
           true:
-            - 'On'
+            - 'Yes'
             - 'Off'
         unselected_value:
           - 'Off'
           - 'Off'
       employment_start:
-        field_name: 'Pa bryd ddechreuodd ei gyflogaeth'
+        field_name: Pa bryd ddechreuodd ei gyflogaeth
       employment_end:
-        field_name: 'Pa bryd ddaeth ei gyflogaeth i ben'
+        field_name: ben
       disagree_with_dates_reason:
-        field_name: 'n anghytuno gydar dyddiadau'
+        field_name: adau
       continuing:
         field_name:
-          - 'Ydy'
-          - 'Nac ydy'
+          - Check Box15
+          - Check Box16
         select_values:
           false:
             - 'Off'
-            - 'On'
+            - 'Yes'
           true:
-            - 'On'
+            - 'Yes'
             - 'Off'
         unselected_value:
           - 'Off'
           - 'Off'
       agree_with_job_title:
         field_name:
-          - 'Ydy_2'
-          - 'Nac ydy_2'
+          - 'Check Box18'
+          - 'Check Box17'
         select_values:
           false:
             - 'Off'
-            - 'On'
+            - 'Yes'
           true:
-            - 'On'
+            - 'Yes'
             - 'Off'
         unselected_value:
           - 'Off'
           - 'Off'
       correct_job_title:
-        field_name: 'n gywir'
+        field_name: onsyngywir
     earnings:
       agree_with_hours:
         field_name:
-          - 'Ydynt_2'
-          - 'Nac ydynt_2'
+          - 'Check Box19'
+          - 'Check Box20'
         select_values:
           false:
             - 'Off'
-            - 'On'
+            - 'Yes'
           true:
-            - 'On'
+            - 'Yes'
             - 'Off'
         unselected_value:
           - 'Off'
           - 'Off'
       correct_hours:
-        field_name: 'n gywir_2'
+        field_name: awryrwythnos
       agree_with_earnings:
         field_name:
-          - 'Ydynt_3'
-          - 'Nac ydynt_3'
+          - Check Box22
+          - Check Box21
         select_values:
           false:
             - 'Off'
-            - 'On'
+            - 'Yes'
           true:
-            - 'On'
+            - 'Yes'
             - 'Off'
         unselected_value:
           - 'Off'
           - 'Off'
       correct_pay_before_tax:
-        field_name: 'fill_4'
+        field_name: fill_4
       correct_pay_before_tax_period:
         field_name:
-          - 'Wythnosol'
-          - 'Misol'
+          - 'Check Box23'
+          - 'Check Box24'
         select_values:
           Monthly:
             - 'Off'
-            - 'On'
+            - 'Yes'
           Weekly:
-            - 'On'
+            - 'Yes'
             - 'Off'
         unselected_value:
           - 'Off'
           - 'Off'
       correct_take_home_pay:
-        field_name: 'fill_5'
+        field_name: fill_5
       correct_take_home_pay_period:
         field_name:
-          - 'Wythnosol_2'
-          - 'Misol_2'
+          - Check Box25
+          - Check Box26
         select_values:
           Monthly:
             - 'Off'
-            - 'On'
+            - 'Yes'
           Weekly:
-            - 'On'
+            - 'Yes'
             - 'Off'
         unselected_value:
           - 'Off'
           - 'Off'
       agree_with_notice_period:
         field_name:
-          - 'Ydy_3'
-          - 'Nac ydy_3'
+          - 'Check Box28'
+          - 'Check Box27'
         select_values:
           false:
             - 'Off'
-            - 'On'
+            - 'Yes'
           true:
-            - 'On'
+            - 'Yes'
             - 'Off'
         unselected_value:
           - 'Off'
           - 'Off'
       disagree_notice_period_reason:
-        field_name: 'weithio ei gyfnod o rybudd eglurwch beth'
+        field_name: weithioei gyfnodorybuddeglurwchbeth
       agree_with_pension_benefits:
         field_name:
-          - 'Ydynt_4'
-          - 'Nac ydynt_4'
+          - 'Check Box30'
+          - 'Check Box29'
         select_values:
           false:
             - 'Off'
-            - 'On'
+            - 'Yes'
           true:
-            - 'On'
+            - 'Yes'
             - 'Off'
         unselected_value:
           - 'Off'
           - 'Off'
       disagree_pension_benefits_reason:
-        field_name: 'n gywir_3'
+        field_name: Osnacydyntrhowchymanylionsyngywir
     response:
       defend_claim:
         field_name:
-          - 'Ydw_2'
-          - 'Nac ydw_2'
+          - 'Check Box31'
+          - 'Check Box32'
         select_values:
           false:
             - 'Off'
-            - 'On'
+            - 'Yes'
           true:
-            - 'On'
+            - 'Yes'
             - 'Off'
         unselected_value:
           - 'Off'
           - 'Off'
       defend_claim_facts:
-        field_name: 'Gweler y Canllaw  Defnyddiwch y dudalen wag ar ddiwedd y ffurflen hon os bydd angen'
+        field_name: Gweler y Can
     contract_claim:
       make_employer_contract_claim:
-        field_name: 'Check Box1'
+        field_name: Check Box33
         select_values:
           true: 'Yes'
           false: 'Off'
       information:
-        field_name: 'gweler y Canllaw am ragor o wybodaeth ynghylch pa fanylion y dylech eu cynnwys'
+        field_name: Rhowchgefndiramanylioneichhawl adisodDy l echgynnwys pobdyddiadpwys g gweleryCan awamragorowybodaethynghy chpa fanylionydy echeucynnwysRow1
     representative:
       name:
-        field_name: 'ch cynrychioli chi llenwch yr wybodaeth ganlynol os gwelwch yn dda  Byddwn yn cysylltu â'
+        field_name: chi
       organisation_name:
-        field_name: 'undefined_8'
+        field_name: undefined_9
       address:
         building:
-          field_name: 'Rhif neu enw_2'
+          field_name: Rhif neu enw_2
         street:
-          field_name: 'Stryd_2'
+          field_name: Stryd_2
         locality:
-          field_name: 'TrefDinas_2'
+          field_name: nas_2
         county:
-          field_name: 'Sir_2'
+          field_name: r_2
         post_code:
-          field_name: 'Cod post_2'
+          field_name: Text10
       dx_number:
-        field_name: 'undefined_9'
+        field_name: undefined_11
       phone_number:
-        field_name: 'undefined_10'
+        field_name: Text5
       mobile_number:
-        field_name: 'undefined_11'
+        field_name: Text6
       reference:
-        field_name: 'Eu cyfeirnod ar gyfer gohebiaeth'
+        field_name: Text7
       contact_preference:
         field_name:
-          - 'Ebost'
-          - 'Post'
-          - 'Ffacs'
+          - Check Box36
+          - Check Box35
+          - Check Box34
         select_values:
           email:
-            - 'On'
+            - 'Yes'
             - 'Off'
             - 'Off'
           fax:
             - 'Off'
             - 'Off'
-            - 'On'
+            - 'Yes'
           post:
             - 'Off'
-            - 'On'
+            - 'Yes'
             - 'Off'
         unselected_value:
           - 'Off'
           - 'Off'
           - 'Off'
       email_address:
-        field_name: 'undefined_12'
+        field_name: Text8
       fax_number:
-        field_name: 'undefined_13'
+        field_name: Text9
     disability:
       has_disability:
         field_name:
-          - 'Oes_2'
-          - 'Nac oes_2'
+          - 'Check Box37'
+          - 'Check Box36'
         select_values:
           false:
             - 'Off'
-            - 'On'
+            - 'Yes'
           true:
-            - 'On'
+            - 'Yes'
             - 'Off'
         unselected_value:
           - 'Off'
           - 'Off'
       information:
-        field_name: 'gynnwys ar gyfer unrhyw wrandawiadau a'
+        field_name: gynnwysargyferunrhywwrandawiadaua
   response_email:
     reference: 'Eich cyfeirnod yw: %{reference}. Dylech ei ddyfynnu ar bob gohebiaeth.'
     submission_date: 'Dyddiad cyflwyno: %{submission_date}'

--- a/test_common/messaging/et3_en.yml
+++ b/test_common/messaging/et3_en.yml
@@ -38,6 +38,12 @@ en:
       fax:
         label: Fax
         input_label: Fax number
+    allow_video_attendance:
+      label: Would you be able to take part in a hearing by video? (Requires internet access).
+      'yes':
+        label: 'Yes'
+      'no':
+        label: 'No'
     organisation_employ_gb:
       label: How many people does this organisation employ in Great Britain? (optional)
     organisation_more_than_one_site:
@@ -454,23 +460,23 @@ en:
           false: ''
     claimant:
       claimants_name:
-        field_name: '1.1'
+        field_name: "1.1 Claimant's name"
     respondent:
       name:
-        field_name: '2.1'
+        field_name: '2.1 name'
       contact:
-        field_name: '2.2'
+        field_name: '2.2 name of contact'
       address:
         building:
-          field_name: '2.3 number or name'
+          field_name: "2.3 Respondent's address: number or name"
         street:
-          field_name: '2.3 street'
+          field_name: "2.3 Respondent's address: street"
         locality:
-          field_name: '2.3 town city'
+          field_name: "2.3 Respondent's address: town city"
         county:
-          field_name: '2.3 county'
+          field_name: "2.3 Respondent's address: county"
         post_code:
-          field_name: '2.3 postcode'
+          field_name: "2.3 Respondent's address: postcode"
       address_dx_number:
         field_name: '2.3 dx number'
       phone_number:
@@ -478,170 +484,310 @@ en:
       mobile_number:
         field_name: '2.4 mobile number'
       contact_preference:
-        field_name: '2.5'
+        field_name:
+          - '2.5 Email'
+          - '2.5 Post'
+          - '2.5 Fax'
         select_values:
-          email: 'email'
-          post: 'post'
-          fax: 'fax'
-        unselected_value: 'Off'
+          email:
+            - email
+            - 'Off'
+            - 'Off'
+          post:
+            - 'Off'
+            - post
+            - 'Off'
+          fax:
+            - 'Off'
+            - 'Off'
+            - fax
+        unselected_value:
+          - 'Off'
+          - 'Off'
+          - 'Off'
       email_address:
         field_name: '2.6 email address'
       fax_number:
         field_name: '2.6 fax number'
-      employ_gb:
-        field_name: '2.7'
-      multi_site_gb:
-        field_name: '2.8'
+      allow_video_attendance:
+        field_name: 'Check Box1'
         select_values:
-          false: 'no'
-          true: 'yes'
+          yes: 'Yes'
+          no: 'no'
         unselected_value: 'Off'
+      employ_gb:
+        field_name: '2.7 number of employees'
+      multi_site_gb:
+        field_name:
+          - "2.8 more than one site - yes"
+          - "2.8 more than one site - no"
+        select_values:
+          false:
+            - "Off"
+            - "no"
+          true:
+            - "yes"
+            - "Off"
+        unselected_value:
+          - 'Off'
+          - 'Off'
       employment_at_site_number:
-        field_name: '2.9'
+        field_name: '2.9 employees employed at that site'
     acas:
       agree:
-        field_name: 'new 3.1'
+        field_name:
+          - '3.1 early conciliation details - yes'
+          - '3.1 early conciliation details - no'
         select_values:
-          false: 'No'
-          true: 'Yes'
-        unselected_value: 'Off'
+          false:
+            - 'Off'
+            - 'No'
+          true:
+            - 'Yes'
+            - 'Off'
+        unselected_value:
+          - 'Off'
+          - 'Off'
       disagree_explanation:
-        field_name: 'new 3.1 If no, please explain why'
+        field_name: '3.1 If no, please explain why'
     employment_details:
       agree_with_dates:
-        field_name: '3.1'
+        field_name:
+          - '4.1 dates correct - yes'
+          - '4.1 dates correct - no'
         select_values:
-          false: 'no'
-          true: 'yes'
-        unselected_value: 'Off'
+          false:
+            - 'Off'
+            - 'no'
+          true:
+            - 'yes'
+            - 'Off'
+        unselected_value:
+          - 'Off'
+          - 'Off'
       employment_start:
-        field_name: '3.1 employment started'
+        field_name: '4.1 employment started'
       employment_end:
-        field_name: '3.1 employment end'
+        field_name: '4.1 employment ended'
       disagree_with_dates_reason:
-        field_name: '3.1 disagree'
+        field_name: "4.1 reasons you disagree with the claimant's dates"
       continuing:
-        field_name: '3.2'
+        field_name:
+          - '4.2 employment continuing - yes'
+          - '4.2 employment continuing - no'
         select_values:
-          no: 'no'
-          yes: 'yes'
-        unselected_value: 'Off'
+          false:
+            - 'Off'
+            - 'no'
+          true:
+            - 'yes'
+            - 'Off'
+        unselected_value:
+          - 'Off'
+          - 'Off'
       agree_with_job_title:
-        field_name: '3.3'
+        field_name:
+          - '4.3 job description correct - yes'
+          - '4.3 job description correct - no'
         select_values:
-          false: 'no'
-          true: 'yes'
-        unselected_value: 'Off'
+          false:
+            - 'Off'
+            - 'no'
+          true:
+            - 'yes'
+            - 'Off'
+        unselected_value:
+          - 'Off'
+          - 'Off'
       correct_job_title:
-        field_name: '3.3 if no'
+        field_name: '4.3 correct details'
     earnings:
       agree_with_hours:
-        field_name: '4.1'
+        field_name:
+          - "5.1 claimant's hours of work are correct - yes"
+          - "5.1 claimant's hours of work are correct - no"
         select_values:
-          false: 'no'
-          true: 'yes'
-        unselected_value: 'Off'
+          false:
+            - 'Off'
+            - 'no'
+          true:
+            - 'yes'
+            - 'Off'
+        unselected_value:
+          - 'Off'
+          - 'Off'
       correct_hours:
-        field_name: '4.1 if no'
+        field_name: 'Work hours details'
       agree_with_earnings:
-        field_name: '4.2'
+        field_name:
+          - '5.2 earning details correct - yes'
+          - '5.2 earning details correct - no'
         select_values:
-          false: 'no'
-          true: 'yes'
-        unselected_value: 'Off'
+          false:
+            - 'Off'
+            - 'no'
+          true:
+            - 'yes'
+            - 'Off'
+        unselected_value:
+          - 'Off'
+          - 'Off'
       correct_pay_before_tax:
-        field_name: '4.2 pay before tax'
+        field_name: '5.2 pay before tax'
       correct_pay_before_tax_period:
-        field_name: '4.2 pay before tax tick box'
+        field_name:
+          - '5.2 pay before tax - weekly'
+          - '5.2 pay before tax - monthly'
         select_values:
-          Monthly: 'monthly'
-          Weekly: 'weekly'
-        unselected_value: 'Off'
+          Monthly:
+            - 'Off'
+            - 'monthly'
+          Weekly:
+            - 'weekly'
+            - 'Off'
+        unselected_value:
+          - 'Off'
+          - 'Off'
       correct_take_home_pay:
-        field_name: '4.2 normal take-home pay'
+        field_name: '5.2 normal take-home pay'
       correct_take_home_pay_period:
-        field_name: '4.2 normal take-home pay tick box'
+        field_name:
+          - '5.2 take-home pay - weekly'
+          - '5.2 take-home pay - monthly'
         select_values:
-          Monthly: 'monthly'
-          Weekly: 'weekly'
-        unselected_value: 'Off'
+          Monthly:
+            - 'Off'
+            - 'monthly'
+          Weekly:
+            - 'weekly'
+            - 'Off'
+        unselected_value:
+          - 'Off'
+          - 'Off'
       agree_with_notice_period:
-        field_name: '4.3 tick box'
+        field_name:
+          - '5.3 period of notice information - correct'
+          - '5.3 period of notice information - not correct'
         select_values:
-          no: 'no'
-          yes: 'yes'
-        unselected_value: 'Off'
+          no:
+            - 'Off'
+            - 'no'
+          yes:
+            - 'yes'
+            - 'Off'
+        unselected_value:
+          - 'Off'
+          - 'Off'
       disagree_notice_period_reason:
-        field_name: '4.3 if no'
+        field_name: '5.3 if information is not correct'
       agree_with_pension_benefits:
-        field_name: '4.4 tick box'
+        field_name:
+          - '5.4 pension details - correct'
+          - '5.4 pension details - not correct'
         select_values:
-          no: 'no'
-          yes: 'yes'
-        unselected_value: 'Off'
+          no:
+            - 'Off'
+            - 'no'
+          yes:
+            - 'yes'
+            - 'Off'
+        unselected_value:
+          - 'Off'
+          - 'Off'
       disagree_pension_benefits_reason:
-        field_name: '4.4 if no'
+        field_name: '5.4 if not correct, details'
     response:
       defend_claim:
-        field_name: '5.1 tick box'
+        field_name:
+          - '6.1 defend the claim - yes'
+          - '6.1 defend the claim - no'
         select_values:
-          no: 'no'
-          yes: 'yes'
-        unselected_value: 'Off'
+          no:
+            - 'Off'
+            - 'no'
+          yes:
+            - 'yes'
+            - 'Off'
+        unselected_value:
+          - 'Off'
+          - 'Off'
       defend_claim_facts:
-        field_name: '5.1 if yes'
+        field_name: '6.1 if yes, facts in defence'
     contract_claim:
       make_employer_contract_claim:
-        field_name: '6.2 tick box'
+        field_name: "7.2 Employer's Contract Claim - yes"
         select_values:
           true: 'yes'
           false: 'Off'
       information:
-        field_name: '6.3'
+        field_name: "7.3 details of Employer's Contract Claim"
     representative:
       name:
-        field_name: '7.1'
+        field_name: '8.1 name of your representative'
       organisation_name:
-        field_name: '7.2'
+        field_name: "8.2 Name of representative's organisation"
       address:
         building:
-          field_name: '7.3 number or name'
+          field_name: "8.3 representative's number or name"
         street:
-          field_name: '7.3 street'
+          field_name: "8.3 representative's street"
         locality:
-          field_name: '7.3 town city'
+          field_name: "8.3 representative's town or city"
         county:
-          field_name: '7.3 county'
+          field_name: "8.3 representative's county"
         post_code:
-          field_name: '7.3 postcode'
+          field_name: "8.3 representative's postcode"
       dx_number:
-        field_name: '7.4'
+        field_name: "8.4 representative's DX number"
       phone_number:
-        field_name: '7.5 phone number'
+        field_name: '8.5 phone number'
       mobile_number:
-        field_name: '7.6'
+        field_name: '8.6 mobile phone number'
       reference:
-        field_name: '7.7'
+        field_name: "8.7 representative's reference for correspondence"
       contact_preference:
-        field_name: '7.8 tick box'
+        field_name:
+          - 8.8 email
+          - 8.8 post
+          - 8.8 fax
         select_values:
-          email: 'email'
-          fax: 'fax'
-          post: 'post'
-        unselected_value: 'Off'
+          email:
+            - 'email'
+            - 'Off'
+            - 'Off'
+          fax:
+            - 'Off'
+            - 'Off'
+            - 'fax'
+          post:
+            - 'Off'
+            - 'post'
+            - 'Off'
+        unselected_value:
+          - 'Off'
+          - 'Off'
+          - 'Off'
       email_address:
-        field_name: '7.9'
+        field_name: '8.9 email address'
       fax_number:
-        field_name: '7.10'
+        field_name: '8.10 fax number'
     disability:
       has_disability:
-        field_name: '8.1 tick box'
+        field_name:
+          - '9.1 disability - yes'
+          - '9.1 disability - no'
         select_values:
-          no: 'no'
-          yes: 'yes'
-        unselected_value: 'Off'
+          no:
+            - 'Off'
+            - 'no'
+          yes:
+            - 'yes'
+            - 'Off'
+        unselected_value:
+          - 'Off'
+          - 'Off'
       information:
-        field_name: '8.1 if yes'
+        field_name: '9.1 details of disability'
   response_email:
     reference: 'This is your reference number: %{reference} which should be quoted on all correspondence.'
     submission_date: 'Submission date: %{submission_date}'

--- a/test_common/page_objects/et1/claimant_details_page.rb
+++ b/test_common/page_objects/et1/claimant_details_page.rb
@@ -170,6 +170,23 @@ module EtFullSystem
               choose(factory_translate(value), name: 'claimant[contact_preference]')
             end
           end
+
+          section :allow_video_attendance, :legend_header, 'simple_form.labels.claimant.allow_video_attendance' do
+            include ::EtFullSystem::Test::I18n
+            element :error_allow_video_attendance, :error, 'activemodel.errors.models.claimant.attributes.allow_video_attendance.blank'
+            element :allow_video_attendance_hint, :paragraph, 'simple_form.hints.claimant.allow_video_attendance'
+            section :yes, :form_labelled, 'simple_form.options.claimant.allow_video_attendance.yes' do
+              element :selector, :css, '#claimant_allow_video_attendance_true'
+              def set(*args); selector.set(*args); end
+            end
+            element :no, :form_labelled, 'simple_form.options.claimant.allow_video_attendance.no' do
+              element :selector, :css, '#claimant_allow_video_attendance_false'
+              def set(*args); selector.set(*args); end
+            end
+            def set(value)
+              choose(factory_translate(value), name: 'claimant[allow_video_attendance]')
+            end
+          end
           #Save and continue
           element :save_and_continue_button, :submit_text, 'helpers.submit.update', exact: false
         end
@@ -227,6 +244,9 @@ module EtFullSystem
           expect(main_content.claimant_contact_preference).to have_contact_preference
           expect(main_content.claimant_contact_preference).to have_email_preference
           expect(main_content.claimant_contact_preference).to have_post_preference
+          # Allow video attendance
+          expect(main_content.allow_video_attendance).to have_yes
+          expect(main_content.allow_video_attendance).to have_no
           #Save and continue
           expect(main_content).to have_save_and_continue_button
           #Support
@@ -259,6 +279,10 @@ module EtFullSystem
           expect(main_content.date_of_birth).to have_invalid_date_of_birth
         end
 
+        def has_correct_invalid_error_message_for_allow_video_attendance?
+          expect(main_content.allow_video_attendance).to have_error_allow_video_attendance
+        end
+
         def has_correct_validation_error_message?
           #Errors on page
           expect(main_content.error_message).to have_error_summary
@@ -273,6 +297,7 @@ module EtFullSystem
           expect(main_content).to have_blank_post_code
           expect(main_content).to have_error_address_county
           expect(main_content.claimant_contact_preference).to have_error_claimant_contact_preference
+          expect(main_content.allow_video_attendance).to have_error_allow_video_attendance
         end
 
         # Fills in the entire page for the user given
@@ -294,6 +319,7 @@ module EtFullSystem
           end
 
           main_content.claimant_contact_preference.set(data[:correspondence])
+          main_content.allow_video_attendance.set(data[:allow_video_attendance])
           main_content.tap do |s|
             set_field(s, :building, data)
             set_field(s, :street, data)

--- a/test_common/page_objects/et3/respondents_details_page.rb
+++ b/test_common/page_objects/et3/respondents_details_page.rb
@@ -126,6 +126,31 @@ module EtFullSystem
             end
           end
         end
+
+        # Does the respondent want to allow a video session ?
+        section :allow_video_attendance_question, :single_choice_option, 'questions.allow_video_attendance.label', exact: false do
+          include ::EtFullSystem::Test::I18n
+          element :error_allow_video_attendance, :error, 'errors.respondents_details.allow_video_attendance.blank'
+          element :has_allow_video_attendance_hint, :paragraph, 'questions.allow_video_attendance.hint'
+          section :yes, :form_labelled, 'questions.allow_video_attendance.yes' do
+            element :selector, :css, 'input'
+            def set(*args); selector.set(*args); end
+          end
+          element :no, :form_labelled, 'questions.allow_video_attendance.no' do
+            element :selector, :css, 'input'
+            def set(*args); selector.set(*args); end
+          end
+
+          def set(value)
+            return if value.nil?
+
+            choose(factory_translate(value), name: 'respondents_detail[video_call]')
+          end
+
+          def set_for(respondent)
+            set(respondent.allow_video_attendance)
+          end
+        end
         # Does this organisation have more than one site in Great Britain?
         section :organisation_employ_gb_question, :question_labelled, 'questions.organisation_employ_gb.label', exact: false do
           element :field, :css, "input"


### PR DESCRIPTION
This PR enhances the test suite to allow for RST-2847 - which is an extra question for asking if the user will allow a video session in both et1 and et3.

This meant new pdf files for both, which in a normal situation should have just meant a line or 2 adding to the pdf mapping files which maps the pdf fields to the normalized fields within our test suite - however, the forms team changed alot more than that, so a lot of re mapping had to be done.

Plus, et1 welsh pdf was post processed manually last time we received it (as they use welsh field name for some odd reason, its the user thats welsh not the computer reading the form !) - but this time, I did not do that, preferring to use the mapping files for what they were intended.